### PR TITLE
Fix contact link/form and align user balance initialization

### DIFF
--- a/game-engine.js
+++ b/game-engine.js
@@ -79,11 +79,11 @@ const GameEngine = {
             }
             
             if (data) {
-                this.userBalance = data.balance;
+                this.userBalance = Math.max(0, Math.round(data.balance || 0));
                 this.updateBalanceDisplay();
             } else {
-                // Usuario nuevo - balance inicial de 1000
-                this.userBalance = 1000;
+                // Usuario nuevo - saldo real inicia en cero hasta recarga
+                this.userBalance = 0;
                 this.updateBalanceDisplay();
             }
         } catch (error) {

--- a/index.html
+++ b/index.html
@@ -529,13 +529,36 @@
         </div>
     </div>
 
+    <!-- Contacto -->
+    <section id="contactSection" class="contact-section">
+        <div class="contact-card">
+            <h2>Contacto</h2>
+            <p>¿Tienes dudas o necesitas ayuda? Escríbenos a <a href="mailto:support@musictokenring.xyz">support@musictokenring.xyz</a>.</p>
+            <form class="contact-form" onsubmit="submitContactForm(event)">
+                <div class="form-group">
+                    <label for="contactName">Nombre</label>
+                    <input type="text" id="contactName" class="form-input" placeholder="Tu nombre" required>
+                </div>
+                <div class="form-group">
+                    <label for="contactEmail">Email</label>
+                    <input type="email" id="contactEmail" class="form-input" placeholder="tu@email.com" required>
+                </div>
+                <div class="form-group">
+                    <label for="contactMessage">Mensaje</label>
+                    <textarea id="contactMessage" class="form-input" rows="4" placeholder="Cuéntanos en qué podemos ayudarte" required></textarea>
+                </div>
+                <button type="submit" class="btn-primary">Enviar mensaje</button>
+            </form>
+        </div>
+    </section>
+
     <!-- Footer -->
     <footer class="footer">
         <div class="footer-content">
             <div class="footer-links">
                 <a href="/privacy.html" class="footer-link">Privacy Policy</a>
                 <a href="/terms.html" class="footer-link">Terms of Service</a>
-                <a href="/cdn-cgi/l/email-protection#d3bfb6b4b2bf93bea6a0bab0a7bcb8b6bda1babdb4fdabaaa9" class="footer-link">Contact</a>
+                <a href="#contactSection" class="footer-link">Contact</a>
             </div>
             <p class="footer-copyright">
                 © 2026 MusicToken Ring. All rights reserved.
@@ -614,6 +637,17 @@
             localStorage.setItem('mtr_preferred_network', network);
             renderWalletDirectory(network);
             showToast(`Red preferida actualizada: ${network.toUpperCase()}`, 'success');
+        }
+
+        function submitContactForm(event) {
+            event.preventDefault();
+            const name = document.getElementById('contactName').value.trim();
+            const email = document.getElementById('contactEmail').value.trim();
+            const message = document.getElementById('contactMessage').value.trim();
+            const subject = encodeURIComponent(`Soporte MusicToken Ring - ${name}`);
+            const body = encodeURIComponent(`Nombre: ${name}\nEmail: ${email}\n\nMensaje:\n${message}`);
+            window.location.href = `mailto:support@musictokenring.xyz?subject=${subject}&body=${body}`;
+            showToast('Abriendo tu cliente de correo para enviar el mensaje.', 'success');
         }
 
         function copyWalletAddress(address, network) {

--- a/privacy.html
+++ b/privacy.html
@@ -223,7 +223,7 @@
                 <li><strong>Retiro de consentimiento:</strong> Retirar tu consentimiento en cualquier momento</li>
             </ul>
             
-            <p>Para ejercer estos derechos, contáctanos en: <strong>privacy@musictokenring.xyz</strong></p>
+            <p>Para ejercer estos derechos, contáctanos en: <strong>support@musictokenring.xyz</strong></p>
         </section>
 
         <section>
@@ -273,7 +273,7 @@
             <h2>12. Contacto</h2>
             <p>Si tienes preguntas sobre esta Política de Privacidad o sobre cómo manejamos tu información personal, contáctanos:</p>
             <ul>
-                <li><strong>Email:</strong> privacy@musictokenring.xyz</li>
+                <li><strong>Email:</strong> support@musictokenring.xyz</li>
                 <li><strong>Sitio web:</strong> www.musictokenring.xyz</li>
             </ul>
         </section>

--- a/profile.html
+++ b/profile.html
@@ -121,7 +121,7 @@
             <div class="footer-links">
                 <a href="/privacy.html" class="footer-link">Privacy Policy</a>
                 <a href="/terms.html" class="footer-link">Terms of Service</a>
-                <a href="mailto:legal@musictokenring.xyz" class="footer-link">Contact</a>
+                <a href="mailto:support@musictokenring.xyz" class="footer-link">Contact</a>
             </div>
             <p class="footer-copyright">
                 © 2026 MusicToken Ring. All rights reserved.

--- a/styles/main.css
+++ b/styles/main.css
@@ -1652,6 +1652,36 @@ body {
     border-color: var(--accent-blue);
 }
 
+
+
+/* === CONTACT SECTION === */
+.contact-section {
+    margin-top: 56px;
+}
+
+.contact-card {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 28px;
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    background: var(--bg-secondary);
+}
+
+.contact-card h2 {
+    margin-bottom: 8px;
+}
+
+.contact-card p {
+    color: var(--text-secondary);
+    margin-bottom: 20px;
+}
+
+.contact-form textarea.form-input {
+    resize: vertical;
+    min-height: 120px;
+}
+
 /* === FOOTER === */
 .footer {
     background: var(--bg-secondary);

--- a/terms.html
+++ b/terms.html
@@ -361,7 +361,7 @@
             <h2>15. Contacto</h2>
             <p>Para preguntas sobre estos términos, contáctanos:</p>
             <ul>
-                <li><strong>Email:</strong> legal@musictokenring.xyz</li>
+                <li><strong>Email:</strong> support@musictokenring.xyz</li>
                 <li><strong>Sitio web:</strong> www.musictokenring.xyz</li>
             </ul>
         </section>


### PR DESCRIPTION
### Motivation
- Restore a working Contact flow on the main site and unify platform contact email to `support@musictokenring.xyz` across pages. 
- Prevent "phantom" user balances by ensuring real user balance values are normalized and default to zero until a real top-up occurs while keeping demo balance behavior for practice mode.

### Description
- Replaced the broken footer contact link on the home page with an in-page anchor to a newly added contact section and form that opens a `mailto:` draft to `support@musictokenring.xyz` via `submitContactForm(event)`.
- Standardized contact addresses to `support@musictokenring.xyz` in `profile.html`, `privacy.html` and `terms.html`.
- Added CSS styles for the contact card/section and textarea in `styles/main.css` to integrate the new block visually.
- Hardened balance loading in `game-engine.js`: existing balances are normalized with `Math.max(0, Math.round(data.balance || 0))` and new users now start with `0` real balance (previously defaulted to 1000); practice/demo balance handling remains unchanged and only used for practice mode.
- Files modified: `index.html`, `game-engine.js`, `profile.html`, `privacy.html`, `terms.html`, `styles/main.css`.

### Testing
- Ran JavaScript syntax checks: `node --check game-engine.js && node --check auth-system.js` (succeeded).
- Verified updated references and the presence of the contact form/UI strings using search (`rg`) for `mailto:`, `support@musictokenring.xyz`, `contactSection`, and balance-related phrases (succeeded).
- Attempted a Playwright-based screenshot to visually validate the new contact section, but Chromium crashed in this environment with a `SIGSEGV` so a UI screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f9e9cedfc832daa2a1cab6ea86bbe)