### PR TITLE
Update streaming partners heading copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
             </section>
 
             <section class="streaming-showcase">
-                <p class="streaming-label">Streaming partners (referencias visuales)</p>
+                <p class="streaming-label">Streaming partners</p>
                 <div class="streaming-logos">
                     <img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/deezer.svg" alt="Deezer" class="streaming-logo" onerror="this.style.display='none'">
                     <img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/spotify.svg" alt="Spotify" class="streaming-logo" onerror="this.style.display='none'">


### PR DESCRIPTION
### Motivation
- Remove the parenthetical Spanish phrase from the streaming showcase label so the heading is concise and reads only `Streaming partners`.

### Description
- Replaced `<p class="streaming-label">Streaming partners (referencias visuales)</p>` with `<p class="streaming-label">Streaming partners</p>` in `index.html`.

### Testing
- Ran `rg -n "Streaming partners" index.html`, served the site with `python3 -m http.server 8000`, captured a screenshot using a Playwright script, and inspected the lines with `nl -ba index.html | sed -n '106,120p'`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990b267e378832d8faf070bf05439c2)