### PR TITLE
feat: integrar módulo Wall Street of Beats con ELO y split 70/30

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
                     <span class="logo-icon">🥊</span>
                     <span class="logo-text">MusicToken Ring</span>
                 </div>
+                <h2 class="slogan">Music Token Ring – The Wall Street of Beats</h2>
                 
                 <div class="header-badges">
                     <span class="badge">🎵 Deezer</span>
@@ -76,6 +77,22 @@
     <!-- Main Content -->
     <main class="main">
         <div class="container">
+            <section id="streamDashboard" class="stream-dashboard">
+                <div class="stream-dashboard-header">
+                    <h2>📈 Wall Street of Beats</h2>
+                    <p>Top streams por región (últimos 5 min)</p>
+                </div>
+                <div class="stream-region-tabs">
+                    <button class="stream-region-tab active" data-region="latam" onclick="setDashboardRegion('latam')">Latam</button>
+                    <button class="stream-region-tab" data-region="us" onclick="setDashboardRegion('us')">US</button>
+                    <button class="stream-region-tab" data-region="eu" onclick="setDashboardRegion('eu')">EU</button>
+                </div>
+                <div class="stream-carousel-wrap">
+                    <button class="stream-carousel-nav" onclick="moveDashboardCarousel(-1)">‹</button>
+                    <div id="streamDashboardTrackList" class="stream-carousel-track"></div>
+                    <button class="stream-carousel-nav" onclick="moveDashboardCarousel(1)">›</button>
+                </div>
+            </section>
             
             <!-- LOGIN WALL (mostrar si no está logueado) -->
             <section id="loginWall" class="login-wall">
@@ -770,7 +787,14 @@
         }
 
         // Seleccionar canción
-        function selectSongForBattle(song) {
+        async function selectSongForBattle(song) {
+            if (typeof GameEngine !== 'undefined' && typeof GameEngine.ensureSongEligibleForMatchmaking === 'function') {
+                const eloGate = await GameEngine.ensureSongEligibleForMatchmaking(song.id);
+                if (!eloGate.allowed) {
+                    showToast(eloGate.reason || 'Canción fuera del rango ELO permitido', 'error');
+                    return;
+                }
+            }
             selectedSong = song;
             
             const cardDiv = document.getElementById('selectedSongCard');

--- a/public/components/StreamDashboard.vue
+++ b/public/components/StreamDashboard.vue
@@ -1,0 +1,12 @@
+<template>
+  <section class="stream-dashboard-shell">
+    <h3>Wall Street of Beats</h3>
+    <p>Componente de referencia para integración en frontend vanilla (index.html + src/app.js).</p>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'StreamDashboard'
+};
+</script>

--- a/styles/main.css
+++ b/styles/main.css
@@ -118,6 +118,79 @@ body {
     background: var(--bg-card);
 }
 
+
+.slogan {
+    font-size: 14px;
+    font-weight: 700;
+    color: #fff;
+    display: block;
+    white-space: nowrap;
+}
+
+.stream-dashboard {
+    margin-bottom: 28px;
+    padding: 16px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 14px;
+}
+
+.stream-dashboard-header h2 {
+    font-size: 20px;
+}
+
+.stream-dashboard-header p {
+    color: var(--text-secondary);
+    font-size: 13px;
+    margin-bottom: 10px;
+}
+
+.stream-region-tabs {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 14px;
+}
+
+.stream-region-tab {
+    border: 1px solid var(--border-color);
+    background: var(--bg-card);
+    color: var(--text-secondary);
+    border-radius: 999px;
+    padding: 6px 12px;
+    cursor: pointer;
+}
+
+.stream-region-tab.active { color: #fff; border-color: var(--accent-green); }
+
+.stream-carousel-wrap { display: flex; gap: 10px; align-items: center; }
+
+.stream-carousel-track {
+    display: flex;
+    gap: 12px;
+    overflow-x: auto;
+    scroll-behavior: smooth;
+    flex: 1;
+}
+
+.stream-card {
+    min-width: 240px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 10px;
+    display: flex;
+    gap: 10px;
+}
+.stream-card img { width: 56px; height: 56px; border-radius: 8px; }
+.stream-card-info { display:flex; flex-direction:column; }
+.stream-card-info strong { font-size: 13px; }
+.stream-card-info span { color: var(--text-secondary); font-size: 12px; }
+.stream-carousel-nav { background: var(--bg-card); color:#fff; border:1px solid var(--border-color); border-radius:50%; width:34px; height:34px; cursor:pointer; }
+.stream-delta.up, .stream-indicator.up { color: var(--accent-green); }
+.stream-delta.down, .stream-indicator.down { color: var(--accent-red); }
+.stream-delta.neutral, .stream-indicator.neutral { color: var(--text-secondary); }
+.stream-indicator { margin-left: 6px; font-weight: 700; }
+
 /* === MAIN CONTENT === */
 .main {
     padding: 48px 0;
@@ -2015,6 +2088,7 @@ body {
 
 /* === RESPONSIVE === */
 @media (max-width: 1024px) {
+    .slogan { display: none; }
     .battle-arena-grid {
         grid-template-columns: 1fr;
     }
@@ -2051,6 +2125,8 @@ body {
 }
 
 @media (max-width: 768px) {
+    .stream-card { min-width: 200px; }
+    .stream-carousel-nav { display: none; }
     .login-wall-title {
         font-size: 28px;
     }


### PR DESCRIPTION
### Motivation
- Añadir un módulo público de "trading musical" (Wall Street of Beats) para mostrar señales de streaming sin tocar la lógica core de práctica ni blockchain. 
- Mejorar emparejamiento evitando batallas con canciones demasiado desbalanceadas por popularidad mediante un sistema ELO invisible. 
- Ajustar el reparto del pozo para reflejar un split 70/30 (ganador/plataforma) y registrar la comisión en transacciones. 

### Description
- Frontend: agrega dashboard visible en home con tabs por región (Latam/US/EU), carrusel y cards que muestran top tracks y delta de streams; archivos: `index.html`, `src/app.js`, `styles/main.css`, y el componente de referencia `public/components/StreamDashboard.vue`.
- Buscador: en `src/app.js` se enrichen resultados con llamadas al endpoint de streams (`/v1/tracks/{id}/streams?interval=5m`) y se muestran indicadores `▲/▼` cuando `current_streams` supera/queda debajo de 1.05/0.95 del `avg_24h`.
- ELO invisible: en `game-engine.js` se añade soporte para tabla `songs_elo` (lectura/creación con default 1000), refresco cada 2 horas (`scheduleEloRefresh`), y funciones `getSongElo`, `canMatchByElo`, `ensureSongEligibleForMatchmaking` y `fetchCpuOpponentByElo` para asegurar que quick/private/practice matching respete una diferencia < 300 puntos.
- Matchmaking y práctica: se filtran candidatos en cola por ELO y se valida ELO antes de unirse a salas privadas; la selección CPU en práctica intenta emparejar por ELO.
- Pool split y fee logging: cálculo de payout ajustado a winner = 70% y platform fee = 30% (`calculateMatchPayouts`), y registro de la comisión en la tabla `transactions` con `type: 'fee'` mediante `logPlatformFeeTransaction`.
- Estilos: añade slogan en header (`.slogan`) visible en desktop y estilos para el dashboard y sus indicadores en `styles/main.css`.

### Testing
- Ejecutado `node --check src/app.js` y `node --check game-engine.js`, ambos pasaron sin errores.
- Monté un servidor local con `python3 -m http.server 8000` y ejecuté un script Playwright que abrió `http://127.0.0.1:8000/index.html` y generó una captura de pantalla del dashboard (artefacto disponible), confirmando render visual del módulo.
- Validaciones automáticas de sintaxis y flujo gráfico (Playwright) completadas con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d719db9c832d96a17c4c53c3323e)