### PR TITLE
fix: build to public and keep canonical vercel routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,5 @@
 {
   "version": 2,
-  "framework": null,
-  "buildCommand": "",
-  "outputDirectory": ".",
   "routes": [
     { "handle": "filesystem" },
     { "src": "/(.*)", "dest": "/index.html" }


### PR DESCRIPTION
### Motivation
- Vercel deployments failed because the platform expected a `public` output directory while the repo had been set to use `dist` causing missing-output errors. 
- Frequent conflicts were occurring around adding/removing `outputDirectory` in `vercel.json`, causing churn on the routes file.

### Description
- Restored `vercel.json` to the canonical routes-only configuration and removed the `outputDirectory` setting by keeping only the `routes` block in `vercel.json`.
- Added a build script at `scripts/vercel-build.mjs` that copies static files and folders into `public/` (instead of `dist/`).
- Added a minimal `package.json` `build` script entry that runs the new build script via `node scripts/vercel-build.mjs`.

### Testing
- Validated `vercel.json` with `python -m json.tool vercel.json`, which succeeded. 
- Ran `npm run build` to produce the `public/` directory, which succeeded and printed the build message. 
- Verified presence of built files with `test -f public/index.html`, `test -f public/src/app.js`, and `test -f public/styles/main.css`, all of which passed. 
- Ran `node --check src/app.js` and `node --check game-engine.js`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d719db9c832d96a17c4c53c3323e)