### PR TITLE
fix: include vercel conflict files in PR auto-resolver

### DIFF
--- a/scripts/resolve-pr-by-number.sh
+++ b/scripts/resolve-pr-by-number.sh
@@ -164,6 +164,8 @@ HOTSPOTS=(
   "styles/main.css"
   "index.html"
   "scripts/resolve-pr-conflicts.sh"
+  "vercel.json"
+  "scripts/vercel-build.mjs"
 )
 
 for f in "${HOTSPOTS[@]}"; do
@@ -187,12 +189,19 @@ if git ls-files -u | grep -q .; then
   exit 6
 fi
 
-if rg -n '^(<<<<<<<|=======|>>>>>>>)' game-engine.js styles/main.css index.html scripts/resolve-pr-conflicts.sh >/dev/null 2>&1; then
+marker_check_files=()
+for f in game-engine.js styles/main.css index.html scripts/resolve-pr-conflicts.sh vercel.json scripts/vercel-build.mjs; do
+  [[ -f "$f" ]] && marker_check_files+=("$f")
+done
+
+if [[ ${#marker_check_files[@]} -gt 0 ]] && rg -n '^(<<<<<<<|=======|>>>>>>>)' "${marker_check_files[@]}" >/dev/null 2>&1; then
   echo "[error] Conflict markers found after resolution" >&2
   exit 7
 fi
 
-node --check game-engine.js >/dev/null
+if [[ -f game-engine.js ]]; then
+  node --check game-engine.js >/dev/null
+fi
 
 if git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1; then
   git add -A

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
### Motivation
- The PR conflict auto-resolver only targeted a few project files and failed to handle recurring merge conflicts in Vercel config and build scripts. 
- Those unresolved Vercel-related conflicts were repeatedly blocking stacked PR merges. 
- The change aims to make the resolver detect and safely resolve the common Vercel hotspots so merges can complete automatically.

### Description
- Added `vercel.json` and `scripts/vercel-build.mjs` to the `HOTSPOTS` list in `scripts/resolve-pr-by-number.sh` so those files are preferentially resolved during conflict resolution. 
- Reworked conflict-marker validation to build a file list dynamically and scan existing files (including the new Vercel-related files) for `<<<<<<<`, `=======`, and `>>>>>>>` markers before committing. 
- Made the `node --check game-engine.js` step conditional on the file existing to avoid failures when that file is not present. 
- Added a simple `vercel.json` with a filesystem handler and a fallback route to `index.html` to stabilize Vercel behavior in this branch.

### Testing
- Ran `bash -n scripts/resolve-pr-by-number.sh` and it returned without syntax errors. (success)
- Ran `node --check game-engine.js` when `game-engine.js` exists and it passed syntax validation. (success)
- Committed the change locally and verified the commit with `git log --oneline --decorate -n 4` and `git status --short --branch`. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d719db9c832d96a17c4c53c3323e)