### PR TITLE
Pulir carrusel del dashboard: scrollbar oculto, arrastre y efecto de iluminación

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -162,7 +162,39 @@ body {
 
 .stream-region-tab.active { color: #fff; border-color: var(--accent-green); }
 
-.stream-carousel-wrap { display: flex; gap: 10px; align-items: center; }
+.stream-carousel-wrap {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    position: relative;
+}
+
+.stream-carousel-wrap::before,
+.stream-carousel-wrap::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 42px;
+    z-index: 2;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+}
+
+.stream-carousel-wrap::before {
+    left: 42px;
+    background: linear-gradient(90deg, rgba(26, 26, 26, 0.95), rgba(26, 26, 26, 0));
+}
+
+.stream-carousel-wrap::after {
+    right: 42px;
+    background: linear-gradient(270deg, rgba(26, 26, 26, 0.95), rgba(26, 26, 26, 0));
+}
+
+.stream-carousel-wrap.glow-active::before,
+.stream-carousel-wrap.glow-active::after {
+    opacity: 0.25;
+}
 
 .stream-carousel-track {
     display: flex;
@@ -170,6 +202,36 @@ body {
     overflow-x: auto;
     scroll-behavior: smooth;
     flex: 1;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    padding-bottom: 4px;
+    cursor: grab;
+    position: relative;
+}
+
+.stream-carousel-track::-webkit-scrollbar {
+    display: none;
+}
+
+.stream-carousel-track:active {
+    cursor: grabbing;
+}
+
+.stream-carousel-track::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -35%;
+    width: 35%;
+    height: 100%;
+    background: linear-gradient(110deg, transparent 0%, rgba(59, 130, 246, 0.12) 45%, transparent 100%);
+    opacity: 0;
+    pointer-events: none;
+    transform: skewX(-16deg);
+}
+
+.stream-carousel-wrap.glow-active .stream-carousel-track::after {
+    animation: streamGlowSlide 0.9s ease;
 }
 
 .stream-card {
@@ -190,6 +252,20 @@ body {
 .stream-delta.down, .stream-indicator.down { color: var(--accent-red); }
 .stream-delta.neutral, .stream-indicator.neutral { color: var(--text-secondary); }
 .stream-indicator { margin-left: 6px; font-weight: 700; }
+
+@keyframes streamGlowSlide {
+    0% {
+        left: -35%;
+        opacity: 0;
+    }
+    25% {
+        opacity: 1;
+    }
+    100% {
+        left: 115%;
+        opacity: 0;
+    }
+}
 
 /* === MAIN CONTENT === */
 .main {
@@ -2127,6 +2203,12 @@ body {
 @media (max-width: 768px) {
     .stream-card { min-width: 200px; }
     .stream-carousel-nav { display: none; }
+    .stream-carousel-wrap::before {
+        left: 0;
+    }
+    .stream-carousel-wrap::after {
+        right: 0;
+    }
     .login-wall-title {
         font-size: 28px;
     }


### PR DESCRIPTION
### Motivation
- Mejorar la presentación del bloque “Wall Street of Beats” para que el desplazamiento horizontal se perciba profesional y limpio sin mostrar ninguna barra nativa. 
- Añadir feedback visual que haga evidente el movimiento deslizable mediante un efecto de iluminación que recorre el carrusel al arrastrar o navegar.

### Description
- Se añadieron estilos en `styles/main.css` para ocultar scrollbars (`scrollbar-width`, `::-webkit-scrollbar`, `-ms-overflow-style`) y aplicar cursor `grab/grabbing` para mejorar la ergonomía táctil/ratón. 
- Se añadieron máscaras de borde (edge fades) y un barrido de brillo (`streamGlowSlide`) que se activa con la clase `glow-active` para simular la iluminación en movimiento. 
- En `src/app.js` se implementó control por puntero para arrastre horizontal (`pointerdown`/`pointermove`/`pointerup`) y se creó `initDashboardDragScroll()` para inicializarlo de forma idempotente. 
- Se añadió `triggerDashboardGlow()` y se conectó la activación del efecto a la navegación por flechas y al scroll manual, además de ajustar el paso de desplazamiento a un valor relativo al ancho del contenedor para una navegación más natural.

### Testing
- Ejecutado `npm run check` (script de verificación rápido) y la comprobación devolvió `ok`. 
- Ejecutado un script automatizado con Playwright que abrió `index.html`, simuló un arrastre horizontal y generó una captura para verificar visualmente el efecto de brillo, la ejecución fue satisfactoria y produjo el artefacto de screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699219fe1dc8832dafb259b3ce001c5a)