### PR TITLE
Reduce noise: Deezer CORS circuit-breaker & Supabase Abort/404 handling

### DIFF
--- a/auth-system.js
+++ b/auth-system.js
@@ -292,6 +292,10 @@ async function loadPlayerProfile(user) {
             }
         }
     } catch (error) {
+        if (error?.name === 'AbortError' || String(error?.message || '').includes('aborted')) {
+            console.warn('Carga de perfil cancelada (AbortError).');
+            return;
+        }
         console.error('Error loading player profile:', error);
         setProfileValue('profileBalance', 'No disponible');
     }
@@ -329,10 +333,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     await processOAuthCallbackIfNeeded();
     
     // Get current session
-    const { data: { session } } = await supabaseClient.auth.getSession();
-    
-    // Update UI
-    updateAuthUI(session);
+    try {
+        const { data: { session } } = await supabaseClient.auth.getSession();
+
+        // Update UI
+        updateAuthUI(session);
+    } catch (error) {
+        if (error?.name === 'AbortError' || String(error?.message || '').includes('aborted')) {
+            console.warn('Inicialización de sesión cancelada (AbortError).');
+            return;
+        }
+        console.error('Error inicializando sesión:', error);
+    }
     
     console.log('✅ Auth system ready!');
 });

--- a/game-engine.js
+++ b/game-engine.js
@@ -89,6 +89,10 @@ const GameEngine = {
                 this.updateBalanceDisplay();
             }
         } catch (error) {
+            if (error?.name === 'AbortError' || String(error?.message || '').includes('aborted')) {
+                console.warn('Carga de balance cancelada (AbortError).');
+                return;
+            }
             console.error('Error loading balance:', error);
         }
     },
@@ -1396,7 +1400,12 @@ const GameEngine = {
                     }, { onConflict: 'track_id' });
 
                 if (error) {
-                    if (error.code === 'PGRST205' || error.message?.includes('relation') || error.message?.includes('songs_elo')) {
+                    if (
+                        error.code === 'PGRST205' ||
+                        error.status === 404 ||
+                        error.message?.includes('relation') ||
+                        error.message?.includes('songs_elo')
+                    ) {
                         this.songsEloTableAvailable = false;
                         console.warn('La tabla songs_elo no existe en Supabase. Se desactiva el refresh automático de ELO.');
                         break;


### PR DESCRIPTION
### Motivation

- Browser console showed repeated noisy errors: Deezer `streams` requests blocked by CORS (TypeError/Failed to fetch) and many parallel retries made the logs noisy and UI churny.  
- Supabase upserts for `songs_elo` returned 404/relation errors repeatedly which triggered ongoing retries.  
- `AbortError` from auth/session/profile/balance flows surfaced as hard errors during initialization instead of benign cancellations.

### Description

- Added a lightweight circuit guard in `src/app.js` (`deezerStreamsCircuitOpen`) to short-circuit concurrent Deezer `streams` fetches and avoid repeated attempts after a browser-side CORS failure, and still return safe default stream values.  
- On Deezer stream fetch failure the code marks the streams endpoint unavailable (`deezerStreamsEndpointAvailable`) and logs a single warning to avoid repeated errors.  
- Improved Supabase error handling in `game-engine.js` by treating `404` (and PostgREST relation errors / `PGRST205`) as “table missing” and disabling the automatic `songs_elo` refresh to stop spammy upsert failures.  
- Downgraded noisy `AbortError` cases to controlled warnings in `game-engine.js` (`loadUserBalance`) and `auth-system.js` (session initialization and `loadPlayerProfile`) so aborted requests don’t surface as runtime errors.

Files changed: `src/app.js`, `game-engine.js`, `auth-system.js`.

### Testing

- Ran `npm run check` which printed `ok` and exited successfully.  
- Ran `npm run build` which completed (project is a static frontend and reported "Static site: no build required").  
- Verified the modified files load syntactically by running the above commands (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699220fedc38832db3b8ce4e86fb9a12)