### PR TITLE
Follow-up: fix concurrent profile loads and Deezer stream fetch regressions from #44

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -37,12 +37,7 @@ let dashboardRegion = 'latam';
 let dashboardCarouselOffset = 0;
 let dashboardGlowTimeout = null;
 let dashboardDragInitialized = false;
- codex/fix-cors-policy-issue-with-deezer-api-4acmrk
 let deezerStreamsEndpointAvailable = Boolean(window?.MTR_ENABLE_DEEZER_STREAMS);
-
-let deezerStreamsEndpointAvailable = true;
- feature/wall-street-v2
-let deezerStreamsCircuitOpen = false;
 const dashboardRegionQueries = { latam: 'latin', us: 'billboard', eu: 'europe top' };
 
 function togglePreview(url, button) {
@@ -156,17 +151,14 @@ function searchDeezer(query, resultsElementId = 'searchResults') {
 // =========================================
 
 async function fetchTrackStreams(trackId) {
-    if (!deezerStreamsEndpointAvailable || deezerStreamsCircuitOpen) {
+    if (!deezerStreamsEndpointAvailable) {
         return { current: 0, avg24h: 0 };
     }
-
-    deezerStreamsCircuitOpen = true;
 
     try {
         const response = await fetch(`https://api.deezer.com/v1/tracks/${trackId}/streams?interval=5m`);
         if (!response.ok) throw new Error('No stream endpoint');
         const data = await response.json();
-        deezerStreamsCircuitOpen = false;
         return {
             current: Number(data.current_streams || 0),
             avg24h: Number(data.avg_24h || 0)
@@ -178,7 +170,6 @@ async function fetchTrackStreams(trackId) {
         } else {
             console.warn('Se desactiva endpoint de streams de Deezer tras error de red/respuesta:', error);
         }
-        deezerStreamsCircuitOpen = false;
         return { current: 0, avg24h: 0 };
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent stale or dropped profile UI when auth changes quickly by removing the global profile-load lock and making per-user in-flight state.  
- Restore correct Deezer stream enrichment for batched result sets by allowing concurrent stream fetches while still suppressing repeated CORS/noise after the first failure.

### Description

- Replaced the global `isLoadingPlayerProfile` with a per-user map `playerProfileLoadStateByUser` and an `activeProfileUserId` marker so profile loads are keyed by `user.id` and overlapping calls for different users are not dropped.  
- When a load for the same user is already in-flight the code now reuses the existing promise and sets `needsReload` so one follow-up reload runs if needed.  
- Added a stale-result guard (`isStaleResult`) so late responses from a previous user do not overwrite the current profile UI or error state.  
- Removed the entry gate that blocked concurrent Deezer stream requests (`deezerStreamsCircuitOpen`) so `Promise.all` batches can fetch streams in parallel, while preserving the global `deezerStreamsEndpointAvailable = false` disable after the first real failure to avoid repeated CORS/TypeError noise.  
- Cleaned stray duplicate/merge-text and consolidated the single authoritative `deezerStreamsEndpointAvailable` declaration.

### Testing

- Verified JS syntax by loading the modified files with `node -e "new Function(require('fs').readFileSync('auth-system.js','utf8')); new Function(require('fs').readFileSync('src/app.js','utf8')); console.log('syntax ok')"` which printed `syntax ok`.  
- Ran `npm run check` which printed `ok`.  
- Ran `npm run build` which completed successfully (`Static site: no build required`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69934f4ecbb0832d88dcccb7bb93e713)