### PR TITLE
Handle missing MetaMask extension errors without noisy console failures

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -37,13 +37,24 @@ let dashboardRegion = 'latam';
 let dashboardCarouselOffset = 0;
 let dashboardGlowTimeout = null;
 let dashboardDragInitialized = false;
- codex/fix-cors-policy-issue-with-deezer-api-4acmrk
 let deezerStreamsEndpointAvailable = Boolean(window?.MTR_ENABLE_DEEZER_STREAMS);
-
-let deezerStreamsEndpointAvailable = true;
- feature/wall-street-v2
 let deezerStreamsCircuitOpen = false;
 const dashboardRegionQueries = { latam: 'latin', us: 'billboard', eu: 'europe top' };
+
+function isMetaMaskExtensionMissingError(reason) {
+    const message = String(reason?.message || reason || '').toLowerCase();
+    return message.includes('metamask extension not found') || message.includes('failed to connect to metamask');
+}
+
+window.addEventListener('unhandledrejection', (event) => {
+    if (!isMetaMaskExtensionMissingError(event.reason)) {
+        return;
+    }
+
+    event.preventDefault();
+    console.warn('MetaMask no está disponible en este navegador.');
+    showToast('MetaMask no está disponible. Instala la extensión para conectar tu wallet.', 'error');
+});
 
 function togglePreview(url, button) {
     if (currentAudio && currentAudio.src === url) {


### PR DESCRIPTION
### Motivation
- Prevent noisy uncaught promise rejections when the MetaMask inpage/provider injection fails and remove stray merge-marker artifacts that could cause malformed runtime behavior.

### Description
- Removed leftover merge-marker/duplicate feature-flag lines in `src/app.js` around the Deezer streams initialization.
- Added `isMetaMaskExtensionMissingError(reason)` helper to detect provider-injection failures originating from MetaMask.
- Added a global `unhandledrejection` listener that intercepts MetaMask-related rejections, prevents the default uncaught error, logs a concise warning, and shows a user-facing toast instructing to install the MetaMask extension.

### Testing
- Ran `node --check src/app.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699363960758832da445b454618f7530)