### PR TITLE
fix: remove merge artifacts and duplicate script includes in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -634,23 +634,14 @@
     <script src="./auth-system.js"></script>
     <script src="./game-engine.js"></script>
     <script>window.MTR_INLINE_TOP_STREAMS_ACTIVE = true;</script>
- codex/fix-unexpected-token-for-error-vhcixr
     <script src="./app.js?v=20260217e"></script>
     <script src="./top-streams-fallback.js?v=20260217e"></script>
-
-    <script src="./src/app.js?v=20260217c"></script>
-    <script src="./src/top-streams-fallback.js?v=20260217d"></script>
- feature/wall-street-v2
 
 
 
 
     <script>
- codex/fix-unexpected-token-for-error-vhcixr
         // Dashboard inline fallback removed; using top-streams-fallback.js
-
- codex/fix-unexpected-token-for-error-k9hk4n
-        // Dashboard inline fallback removed; using src/top-streams-fallback.js
 
 
         (function () {
@@ -812,9 +803,6 @@
 
             });
         })();
- feature/wall-street-v2
- feature/wall-street-v2
-
         // Variables globales
         let selectedSong = null;
         let currentMode = null;


### PR DESCRIPTION
### Motivation
- Eliminar texto residual de fusiones fallidas (por ejemplo `codex/...`, `feature/...`) y evitar la carga duplicada de scripts que rompían el arranque del frontend en `index.html`.

### Description
- Se eliminaron las líneas inyectadas por merges fallidos en la zona de `<script>` y se quitaron los includes duplicados de `./src/app.js` y `./src/top-streams-fallback.js`, dejando la ruta de producción `./app.js` y `./top-streams-fallback.js` intactas.

### Testing
- Se ejecutó `npm run check` (que corre `node --check` sobre los JS y un guard que busca patrones de merge conflict); la verificación terminó con `guard-ok` y no se detectaron patrones bloqueantes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0efd506c832db0a1d0751ffa0448)