### PR TITLE
fix: remove merge-artifact markers and duplicate runtime script includes from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,26 +639,16 @@
     <script src="./auth-system.js"></script>
     <script src="./game-engine.js"></script>
     <script>window.MTR_INLINE_TOP_STREAMS_ACTIVE = true;</script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
     <script src="./app.js?v=20260222b"></script>
     <script src="./top-streams-fallback.js?v=20260222b"></script>
 
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
-    <script src="./app.js?v=20260222a"></script>
-    <script src="./top-streams-fallback.js?v=20260222a"></script>
 
-    <script src="./app.js?v=20260217e"></script>
-    <script src="./top-streams-fallback.js?v=20260217e"></script>
- feature/wall-street-v2
- feature/wall-street-v2
 
 
 
 
     <script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
 
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
 
         // Dashboard inline fallback removed; using top-streams-fallback.js
 
@@ -822,8 +812,6 @@
 
             });
         })();
- feature/wall-street-v2
- feature/wall-street-v2
         // Variables globales
         let selectedSong = null;
         let currentMode = null;


### PR DESCRIPTION
### Motivation
- Eliminar artefactos de merge y entradas duplicadas de scripts en `index.html` que activaban bloqueos por patrones prohibidos y contaban referencias de scripts inválidas en la verificación de integridad en tiempo de ejecución.

### Description
- Quité cadenas incrustadas de ramas/merge (`codex/...` y `feature/wall-street-v2`) presentes en `index.html`.
- Eliminé inclusiones duplicadas de runtime dejando una única versión para `app.js` y `top-streams-fallback.js`.
- Conservé la lógica de fallback inline y las funciones existentes sin modificar su comportamiento funcional.

### Testing
- Ejecuté `npm run check` y la tarea completó correctamente con `runtime-integrity-ok` reportado por `scripts/verify-runtime-integrity.js`.
- Los comprobadores de sintaxis incluidos en el script (`node --check` sobre los ficheros JS) pasaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3de759e4832db0a3adf36e92b562)