### PR TITLE
fix: avoid duplicate app initialization, add selectMode fallback, and clean index.html artifacts

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,10 @@
+(function (global) {
+    if (global.__MTR_APP_JS_LOADED__) {
+        console.warn('app.js already loaded; skipping duplicate initialization.');
+        return;
+    }
+    global.__MTR_APP_JS_LOADED__ = true;
+
 // =========================================
 // APP.JS - MusicToken Ring
 // Funciones auxiliares de búsqueda y audio
@@ -537,3 +544,5 @@ if (!window.MTR_INLINE_TOP_STREAMS_ACTIVE) {
     window.setDashboardRegion = setDashboardRegion;
     window.moveDashboardCarousel = moveDashboardCarousel;
 }
+
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/game-engine.js
+++ b/game-engine.js
@@ -1747,3 +1747,27 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('🎮 GameEngine loaded!');
     }
 });
+
+// Fallback UI handlers: keep mode buttons functional even if inline script fails to parse.
+if (typeof window !== 'undefined' && typeof window.selectMode !== 'function') {
+    window.selectMode = function selectModeFallback(mode) {
+        const modeSelector = document.getElementById('modeSelector');
+        const songSelection = document.getElementById('songSelection');
+        const modeTitle = document.getElementById('modeTitle');
+        const titles = {
+            quick: 'Modo Rápido',
+            private: 'Sala Privada',
+            practice: 'Modo Práctica',
+            tournament: 'Modo Torneo'
+        };
+
+        window.currentMode = mode;
+        if (modeSelector) modeSelector.classList.add('hidden');
+        if (songSelection) songSelection.classList.remove('hidden');
+        if (modeTitle) modeTitle.textContent = titles[mode] || 'Modo de Juego';
+
+        if (window.GameEngine && typeof window.GameEngine.updatePracticeBetDisplay === 'function') {
+            window.GameEngine.updatePracticeBetDisplay();
+        }
+    };
+}

--- a/index.html
+++ b/index.html
@@ -639,26 +639,16 @@
     <script src="./auth-system.js"></script>
     <script src="./game-engine.js"></script>
     <script>window.MTR_INLINE_TOP_STREAMS_ACTIVE = true;</script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
     <script src="./app.js?v=20260222b"></script>
     <script src="./top-streams-fallback.js?v=20260222b"></script>
 
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
-    <script src="./app.js?v=20260222a"></script>
-    <script src="./top-streams-fallback.js?v=20260222a"></script>
 
-    <script src="./app.js?v=20260217e"></script>
-    <script src="./top-streams-fallback.js?v=20260217e"></script>
- feature/wall-street-v2
- feature/wall-street-v2
 
 
 
 
     <script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
 
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
 
         // Dashboard inline fallback removed; using top-streams-fallback.js
 
@@ -822,8 +812,6 @@
 
             });
         })();
- feature/wall-street-v2
- feature/wall-street-v2
         // Variables globales
         let selectedSong = null;
         let currentMode = null;

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,10 @@
+(function (global) {
+    if (global.__MTR_APP_JS_LOADED__) {
+        console.warn('app.js already loaded; skipping duplicate initialization.');
+        return;
+    }
+    global.__MTR_APP_JS_LOADED__ = true;
+
 // =========================================
 // APP.JS - MusicToken Ring
 // Funciones auxiliares de búsqueda y audio
@@ -537,3 +544,5 @@ if (!window.MTR_INLINE_TOP_STREAMS_ACTIVE) {
     window.setDashboardRegion = setDashboardRegion;
     window.moveDashboardCarousel = moveDashboardCarousel;
 }
+
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));


### PR DESCRIPTION
### Motivation
- Prevent runtime `Identifier ... has already been declared` and duplicate-initialization errors caused by multiple app bundle inclusions. 
- Recover UI behavior when an inline script fails to parse and leaves `selectMode` undefined, which produced `selectMode is not defined` on button clicks. 
- Remove merge-artifact duplicate script markers in `index.html` that produced invalid tokens and blocked clean deploys.

### Description
- Added an IIFE guard around `app.js` and `src/app.js` that sets `__MTR_APP_JS_LOADED__` on the global and short-circuits duplicate execution to prevent redeclaration errors. 
- Added a defensive fallback `selectMode` in `game-engine.js` that only defines the function when `window.selectMode` is not present and preserves basic mode-selection UI behavior and calls into `GameEngine.updatePracticeBetDisplay()` when available. 
- Cleaned `index.html` to remove duplicated/garbage script includes and normalized the script loading order so only the intended `app.js`/`top-streams-fallback.js` variants are included. 

### Testing
- Ran `npm run check` (which performs `node --check` on bundles and runs `scripts/verify-runtime-integrity.js`) and it completed successfully with `runtime-integrity-ok`. 
- Attempted an automated Playwright-based page screenshot validation, but the Playwright/Chromium run failed with a `SIGSEGV` crash in the CI environment, so the browser screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3de759e4832db0a3adf36e92b562)