### PR TITLE
Agregar fallbacks para selectMode/backToModes y actualizar build id frontend

### DIFF
--- a/app.js
+++ b/app.js
@@ -540,6 +540,35 @@ window.searchDeezer = searchDeezer;
 window.displaySearchResults = displaySearchResults;
 window.handleTrackSelect = handleTrackSelect;
 
+// Fallbacks: keep mode buttons functional even if inline scripts fail to parse/load.
+if (typeof window.selectMode !== 'function') {
+    window.selectMode = function selectModeFallback(mode) {
+        const modeSelector = document.getElementById('modeSelector');
+        const songSelection = document.getElementById('songSelection');
+        const modeTitle = document.getElementById('modeTitle');
+        const titles = {
+            quick: '⚔️ Modo Rápido',
+            private: '🎪 Sala Privada',
+            tournament: '🏆 Torneo',
+            practice: '🎯 Práctica'
+        };
+
+        if (modeSelector) modeSelector.classList.add('hidden');
+        if (songSelection) songSelection.classList.remove('hidden');
+        if (modeTitle) modeTitle.textContent = titles[mode] || '🎮 Seleccionar Modo';
+        window.currentMode = mode || null;
+    };
+}
+
+if (typeof window.backToModes !== 'function') {
+    window.backToModes = function backToModesFallback() {
+        const modeSelector = document.getElementById('modeSelector');
+        const songSelection = document.getElementById('songSelection');
+        if (songSelection) songSelection.classList.add('hidden');
+        if (modeSelector) modeSelector.classList.remove('hidden');
+    };
+}
+
 if (!window.MTR_INLINE_TOP_STREAMS_ACTIVE) {
     window.setDashboardRegion = setDashboardRegion;
     window.moveDashboardCarousel = moveDashboardCarousel;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <meta name="mtr-build" content="20260222b">
+    <meta name="mtr-build" content="20260222c">
     <title>MusicToken Ring - Music Battle Arena</title>
    
     <!-- Fonts -->
@@ -63,7 +63,7 @@
             solana: 'AavRs1c4CmBDcJ2KzTh5C8btwbLv7CnCRbA6EpEJqaNr',
             bitcoin: 'bc1qtjwwj5lwsn4r5pjg8l30r4s5p843g4p344tr6a'
         };
-        window.MTR_BUILD_ID = '20260222b';
+        window.MTR_BUILD_ID = '20260222c';
         console.log('🎵 MusicToken Ring loaded! build=' + window.MTR_BUILD_ID);
     </script>
 </head>
@@ -639,8 +639,8 @@
     <script src="./auth-system.js"></script>
     <script src="./game-engine.js"></script>
     <script>window.MTR_INLINE_TOP_STREAMS_ACTIVE = true;</script>
-    <script src="./app.js?v=20260222b"></script>
-    <script src="./top-streams-fallback.js?v=20260222b"></script>
+    <script src="./app.js?v=20260222c"></script>
+    <script src="./top-streams-fallback.js?v=20260222c"></script>
 
 
 

--- a/src/app.js
+++ b/src/app.js
@@ -540,6 +540,35 @@ window.searchDeezer = searchDeezer;
 window.displaySearchResults = displaySearchResults;
 window.handleTrackSelect = handleTrackSelect;
 
+// Fallbacks: keep mode buttons functional even if inline scripts fail to parse/load.
+if (typeof window.selectMode !== 'function') {
+    window.selectMode = function selectModeFallback(mode) {
+        const modeSelector = document.getElementById('modeSelector');
+        const songSelection = document.getElementById('songSelection');
+        const modeTitle = document.getElementById('modeTitle');
+        const titles = {
+            quick: '⚔️ Modo Rápido',
+            private: '🎪 Sala Privada',
+            tournament: '🏆 Torneo',
+            practice: '🎯 Práctica'
+        };
+
+        if (modeSelector) modeSelector.classList.add('hidden');
+        if (songSelection) songSelection.classList.remove('hidden');
+        if (modeTitle) modeTitle.textContent = titles[mode] || '🎮 Seleccionar Modo';
+        window.currentMode = mode || null;
+    };
+}
+
+if (typeof window.backToModes !== 'function') {
+    window.backToModes = function backToModesFallback() {
+        const modeSelector = document.getElementById('modeSelector');
+        const songSelection = document.getElementById('songSelection');
+        if (songSelection) songSelection.classList.add('hidden');
+        if (modeSelector) modeSelector.classList.remove('hidden');
+    };
+}
+
 if (!window.MTR_INLINE_TOP_STREAMS_ACTIVE) {
     window.setDashboardRegion = setDashboardRegion;
     window.moveDashboardCarousel = moveDashboardCarousel;


### PR DESCRIPTION
### Motivation
- Los botones de modo fallaban con `selectMode is not defined` cuando el bloque inline grande en `index.html` no se parseaba o cuando clientes cargaban mezclas de versiones en caché que generaban declaraciones duplicadas.
- Se requiere una solución defensiva mínima que haga que los botones sigan funcionando aun si el script inline falla o hay conflicto de versiones.

### Description
- Se añadieron fallbacks defensivos para `selectMode` y `backToModes` en `app.js` y `src/app.js` para exponer funciones globales mínimas que mantienen la UI de selección de modo operativa.
- Se actualizó el identificador de build y los query strings de los assets en `index.html` de `20260222b` a `20260222c` para forzar una recarga coherente de los scripts cliente y reducir colisiones de caché.
- Los fallbacks sólo manipulan visibilidad de secciones y título (`modeSelector`, `songSelection`, `modeTitle`) y no cambian la lógica del `GameEngine` ni las APIs existentes.

### Testing
- Se ejecutó `node --check app.js` y la verificación de sintaxis fue exitosa.
- Se ejecutó `node --check src/app.js` y la verificación de sintaxis fue exitosa.
- Se extrajeron los bloques de script inline de `index.html` y cada bloque fue verificado con `node --check`, y todas las comprobaciones pasaron.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b4822d804832d800532180b4ce5c1)