### PR TITLE
Hotfix: make mode buttons resilient — add selectMode/backToModes fallback and harden buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,37 @@
             bitcoin: 'bc1qtjwwj5lwsn4r5pjg8l30r4s5p843g4p344tr6a'
         };
         window.MTR_BUILD_ID = '20260222c';
+
+        // Critical UI fallbacks: keep mode buttons functional even if a later script fails to parse/load.
+        if (typeof window.selectMode !== 'function') {
+            window.selectMode = function selectModeCriticalFallback(mode) {
+                var modeSelector = document.getElementById('modeSelector');
+                var songSelection = document.getElementById('songSelection');
+                var modeTitle = document.getElementById('modeTitle');
+                var titles = {
+                    quick: 'Modo Rápido',
+                    private: 'Sala Privada',
+                    practice: 'Modo Práctica',
+                    tournament: 'Modo Torneo'
+                };
+
+                window.currentMode = mode || null;
+                if (modeSelector) modeSelector.classList.add('hidden');
+                if (songSelection) songSelection.classList.remove('hidden');
+                if (modeTitle) modeTitle.textContent = titles[mode] || 'Modo de Juego';
+            };
+        }
+
+        if (typeof window.backToModes !== 'function') {
+            window.backToModes = function backToModesCriticalFallback() {
+                var modeSelector = document.getElementById('modeSelector');
+                var songSelection = document.getElementById('songSelection');
+                if (songSelection) songSelection.classList.add('hidden');
+                if (modeSelector) modeSelector.classList.remove('hidden');
+                window.currentMode = null;
+            };
+        }
+
         console.log('🎵 MusicToken Ring loaded! build=' + window.MTR_BUILD_ID);
     </script>
 </head>
@@ -85,7 +116,7 @@
                 </div>
 
                 <div class="wallet-section">
-                    <button onclick="connectWallet()" class="btn-secondary btn-wallet">
+                    <button type="button" onclick="connectWallet()" class="btn-secondary btn-wallet">
                         🦊 Conectar Wallet
                     </button>
                     <span id="walletAddress" class="wallet-address hidden"></span>
@@ -93,7 +124,7 @@
                 
                 <!-- AUTH BUTTON -->
                 <div id="authButton">
-                    <button onclick="openAuthModal()" class="btn-login">
+                    <button type="button" onclick="openAuthModal()" class="btn-login">
                         Iniciar Sesión
                     </button>
                 </div>
@@ -110,12 +141,12 @@
                     <p>Top streams por región (últimos 5 min)</p>
                 </div>
                 <div class="stream-region-tabs">
-                    <button class="stream-region-tab active" data-region="latam" onclick="setDashboardRegion('latam')">Latam</button>
-                    <button class="stream-region-tab" data-region="us" onclick="setDashboardRegion('us')">US</button>
-                    <button class="stream-region-tab" data-region="eu" onclick="setDashboardRegion('eu')">EU</button>
+                    <button type="button" class="stream-region-tab active" data-region="latam" onclick="setDashboardRegion('latam')">Latam</button>
+                    <button type="button" class="stream-region-tab" data-region="us" onclick="setDashboardRegion('us')">US</button>
+                    <button type="button" class="stream-region-tab" data-region="eu" onclick="setDashboardRegion('eu')">EU</button>
                 </div>
                 <div class="stream-carousel-wrap">
-                    <button class="stream-carousel-nav" onclick="moveDashboardCarousel(-1)">‹</button>
+                    <button type="button" class="stream-carousel-nav" onclick="moveDashboardCarousel(-1)">‹</button>
                     <div id="streamDashboardTrackList" class="stream-carousel-track">
                         <article class="stream-card">
                             <img src="https://e-cdns-images.dzcdn.net/images/cover/9f4c9025e2f4f4be85a8d0f95f3bc5fe/250x250-000000-80-0-0.jpg" alt="Luna">
@@ -142,7 +173,7 @@
                             </div>
                         </article>
                     </div>
-                    <button class="stream-carousel-nav" onclick="moveDashboardCarousel(1)">›</button>
+                    <button type="button" class="stream-carousel-nav" onclick="moveDashboardCarousel(1)">›</button>
                 </div>
             </section>
             
@@ -154,7 +185,7 @@
                     <p class="login-wall-subtitle">
                         Batalla con tus canciones favoritas, apuesta $MTOKEN y demuestra quién tiene mejor gusto musical
                     </p>
-                    <button onclick="openAuthModal()" class="btn-primary btn-large">
+                    <button type="button" onclick="openAuthModal()" class="btn-primary btn-large">
                         Iniciar Sesión para Jugar
                     </button>
                     <div class="login-wall-features">
@@ -221,7 +252,7 @@
                             <input id="depositTxHash" class="payment-input" type="text" placeholder="0x... hash de transacción">
                             <input id="depositAmount" class="payment-input" type="number" min="1" placeholder="Monto enviado (opcional)">
                         </div>
-                        <button class="btn-secondary" onclick="verifyDepositTx()">✅ Verificar y acreditar recarga</button>
+                        <button type="button" class="btn-secondary" onclick="verifyDepositTx()">✅ Verificar y acreditar recarga</button>
                     </div>
 
                     <div class="settlement-card">
@@ -231,10 +262,10 @@
                         </p>
                         <div class="settlement-grid">
                             <input id="cashoutAmount" class="payment-input" type="number" min="1" placeholder="MTOKEN a retirar">
-                            <button class="btn-secondary" onclick="quoteCashout()">📊 Cotizar en USD</button>
+                            <button type="button" class="btn-secondary" onclick="quoteCashout()">📊 Cotizar en USD</button>
                         </div>
                         <p class="settlement-quote" id="cashoutQuote">Sin cotización aún.</p>
-                        <button class="btn-primary" onclick="requestCashout()">💸 Solicitar retiro</button>
+                        <button type="button" class="btn-primary" onclick="requestCashout()">💸 Solicitar retiro</button>
                     </div>
                 </div>
             </section>
@@ -248,7 +279,7 @@
 
                 <div class="modes-grid">
                     <!-- Modo Rápido -->
-                    <div class="mode-card" onclick="event.stopPropagation(); selectMode('quick');">
+                    <div class="mode-card" onclick="selectMode('quick')">
                         <div class="mode-icon">⚔️</div>
                         <h3 class="mode-title">Modo Rápido</h3>
                         <p class="mode-description">
@@ -259,11 +290,11 @@
                             <span class="mode-feature">💰 Apuesta personalizada</span>
                             <span class="mode-feature">⏱️ Partidas de 1 minuto</span>
                         </div>
-                        <button class="btn-mode" onclick="event.stopPropagation(); selectMode('quick');">Jugar Ahora</button>
+                        <button type="button" class="btn-mode" onclick="selectMode('quick')">Jugar Ahora</button>
                     </div>
 
                     <!-- Sala Privada -->
-                    <div class="mode-card" onclick="event.stopPropagation(); selectMode('private');">
+                    <div class="mode-card" onclick="selectMode('private')">
                         <div class="mode-icon">🎪</div>
                         <h3 class="mode-title">Sala Privada</h3>
                         <p class="mode-description">
@@ -274,11 +305,11 @@
                             <span class="mode-feature">🔗 Código de sala único</span>
                             <span class="mode-feature">⚙️ Reglas personalizadas</span>
                         </div>
-                        <button class="btn-mode" onclick="event.stopPropagation(); selectMode('private');">Crear Sala</button>
+                        <button type="button" class="btn-mode" onclick="selectMode('private')">Crear Sala</button>
                     </div>
 
                     <!-- Torneo -->
-                    <div class="mode-card" onclick="event.stopPropagation(); selectMode('tournament');">
+                    <div class="mode-card" onclick="selectMode('tournament')">
                         <div class="mode-icon">🏆</div>
                         <h3 class="mode-title">Torneo</h3>
                         <p class="mode-description">
@@ -289,11 +320,11 @@
                             <span class="mode-feature">💎 Grandes premios</span>
                             <span class="mode-feature">🏅 Rankings globales</span>
                         </div>
-                        <button class="btn-mode" onclick="event.stopPropagation(); selectMode('tournament');">Unirse al Torneo</button>
+                        <button type="button" class="btn-mode" onclick="selectMode('tournament')">Unirse al Torneo</button>
                     </div>
 
                     <!-- Modo Práctica -->
-                    <div class="mode-card" onclick="event.stopPropagation(); selectMode('practice');">
+                    <div class="mode-card" onclick="selectMode('practice')">
                         <div class="mode-icon">🎯</div>
                         <h3 class="mode-title">Modo Práctica</h3>
                         <p class="mode-description">
@@ -304,7 +335,7 @@
                             <span class="mode-feature">🎁 Pequeñas recompensas</span>
                             <span class="mode-feature">📚 Aprende a jugar</span>
                         </div>
-                        <button class="btn-mode" onclick="event.stopPropagation(); selectMode('practice');">Practicar</button>
+                        <button type="button" class="btn-mode" onclick="selectMode('practice')">Practicar</button>
                     </div>
                 </div>
             </section>
@@ -312,7 +343,7 @@
             <!-- SELECCIÓN DE CANCIÓN Y APUESTA -->
             <section id="songSelection" class="hidden">
                 <div class="section-header">
-                    <button onclick="backToModes()" class="btn-back">← Volver</button>
+                    <button type="button" onclick="backToModes()" class="btn-back">← Volver</button>
                     <h2 class="section-title" id="modeTitle">Modo Rápido</h2>
                     <p class="section-subtitle">Elige tu canción y realiza tu apuesta</p>
                 </div>
@@ -328,7 +359,7 @@
                                 placeholder="Nombre de canción o artista..."
                                 class="search-input"
                             >
-                            <button onclick="searchSong()" class="search-btn">🔍</button>
+                            <button type="button" onclick="searchSong()" class="search-btn">🔍</button>
                         </div>
 
                         <!-- Resultados -->
@@ -358,10 +389,10 @@
                                 class="bet-input"
                             >
                             <div class="bet-quick">
-                                <button onclick="quickBet(100)" class="btn-quick">100</button>
-                                <button onclick="quickBet(500)" class="btn-quick">500</button>
-                                <button onclick="quickBet(1000)" class="btn-quick">1K</button>
-                                <button onclick="quickBet(5000)" class="btn-quick">5K</button>
+                                <button type="button" onclick="quickBet(100)" class="btn-quick">100</button>
+                                <button type="button" onclick="quickBet(500)" class="btn-quick">500</button>
+                                <button type="button" onclick="quickBet(1000)" class="btn-quick">1K</button>
+                                <button type="button" onclick="quickBet(5000)" class="btn-quick">5K</button>
                             </div>
 
                             <!-- Botones según modo -->
@@ -377,7 +408,7 @@
                     <div class="waiting-spinner">⏳</div>
                     <h2 class="waiting-title">Buscando Oponente...</h2>
                     <p class="waiting-subtitle">Esto puede tomar unos segundos</p>
-                    <button onclick="cancelSearch()" class="btn-secondary">Cancelar Búsqueda</button>
+                    <button type="button" onclick="cancelSearch()" class="btn-secondary">Cancelar Búsqueda</button>
                 </div>
             </section>
 
@@ -389,14 +420,14 @@
                         <div class="room-code-display">
                             <span>Código:</span>
                             <strong id="roomCode">XXXXX</strong>
-                            <button onclick="copyRoomCode()" class="btn-copy">📋</button>
+                            <button type="button" onclick="copyRoomCode()" class="btn-copy">📋</button>
                         </div>
                     </div>
                     <div class="room-invite">
                         <label for="roomInviteLink">Link privado para invitar</label>
                         <div class="room-invite-actions">
                             <input id="roomInviteLink" type="text" readonly class="room-invite-input">
-                            <button onclick="copyRoomLink()" class="btn-secondary">Copiar link</button>
+                            <button type="button" onclick="copyRoomLink()" class="btn-secondary">Copiar link</button>
                         </div>
                     </div>
                     <div class="room-players">
@@ -411,7 +442,7 @@
                         </div>
                     </div>
                     <p class="room-info">Comparte el código con tu amigo</p>
-                    <button onclick="leaveRoom()" class="btn-secondary">Salir de la Sala</button>
+                    <button type="button" onclick="leaveRoom()" class="btn-secondary">Salir de la Sala</button>
                 </div>
             </section>
 
@@ -425,7 +456,7 @@
     <div id="authModal" class="modal hidden">
         <div class="modal-overlay" onclick="closeAuthModal()"></div>
         <div class="modal-content auth-modal-content">
-            <button onclick="closeAuthModal()" class="modal-close">×</button>
+            <button type="button" onclick="closeAuthModal()" class="modal-close">×</button>
             
             <!-- Login Form -->
             <div id="loginForm" class="auth-form">
@@ -433,7 +464,7 @@
                 <p class="auth-subtitle">Accede a tu cuenta para guardar tu progreso</p>
                 
                 <!-- Google Login -->
-                <button onclick="loginWithGoogle()" class="btn-google">
+                <button type="button" onclick="loginWithGoogle()" class="btn-google">
                     <svg width="18" height="18" viewBox="0 0 18 18">
                         <path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"/>
                         <path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332C2.438 15.983 5.482 18 9 18z"/>
@@ -488,7 +519,7 @@
                 <p class="auth-subtitle">Únete a MusicToken Ring</p>
                 
                 <!-- Google Signup -->
-                <button onclick="loginWithGoogle()" class="btn-google">
+                <button type="button" onclick="loginWithGoogle()" class="btn-google">
                     <svg width="18" height="18" viewBox="0 0 18 18">
                         <path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"/>
                         <path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332C2.438 15.983 5.482 18 9 18z"/>
@@ -555,7 +586,7 @@
     <div id="profileModal" class="modal hidden">
         <div class="modal-overlay" onclick="closeProfileModal()"></div>
         <div class="modal-content profile-modal-content">
-            <button onclick="closeProfileModal()" class="modal-close">×</button>
+            <button type="button" onclick="closeProfileModal()" class="modal-close">×</button>
             <h2 class="auth-title">Perfil del Jugador</h2>
             <p class="auth-subtitle">Resumen de rendimiento y actividad reciente</p>
 
@@ -588,12 +619,12 @@
     <div id="challengeModal" class="modal hidden">
         <div class="modal-overlay" onclick="closeChallengeModal()"></div>
         <div class="modal-content">
-            <button onclick="closeChallengeModal()" class="modal-close">×</button>
+            <button type="button" onclick="closeChallengeModal()" class="modal-close">×</button>
             <h2 class="auth-title">⚔️ Reto Rápido</h2>
             <p class="auth-subtitle" id="challengeDetails">Tienes un reto pendiente</p>
             <div class="challenge-actions">
-                <button onclick="acceptChallenge()" class="btn-primary btn-block">Aceptar</button>
-                <button onclick="rejectChallenge()" class="btn-secondary btn-block">Rechazar</button>
+                <button type="button" onclick="acceptChallenge()" class="btn-primary btn-block">Aceptar</button>
+                <button type="button" onclick="rejectChallenge()" class="btn-secondary btn-block">Rechazar</button>
             </div>
         </div>
     </div>
@@ -922,7 +953,7 @@
                 <div class="wallet-item">
                     <span class="wallet-network">${label}</span>
                     <span class="wallet-value">${selectedAddress}</span>
-                    <button class="wallet-copy" onclick="copyWalletAddress('${selectedAddress}', '${activeNetwork}')">Copiar</button>
+                    <button type="button" class="wallet-copy" onclick="copyWalletAddress('${selectedAddress}', '${activeNetwork}')">Copiar</button>
                 </div>
             `;
         }
@@ -964,26 +995,26 @@
             
             if (mode === 'quick') {
                 buttonsDiv.innerHTML = `
-                    <button onclick="startQuickMatch()" class="btn-primary btn-large" id="startQuickBtn" disabled>
+                    <button type="button" onclick="startQuickMatch()" class="btn-primary btn-large" id="startQuickBtn" disabled>
                         ⚔️ Buscar Rival
                     </button>
                 `;
             } else if (mode === 'private') {
                 buttonsDiv.innerHTML = `
-                    <button onclick="createRoom()" class="btn-primary" id="createRoomBtn" disabled>
+                    <button type="button" onclick="createRoom()" class="btn-primary" id="createRoomBtn" disabled>
                         🎪 Crear Sala
                     </button>
                     <div class="or-divider">o</div>
                     <div class="join-room-group">
                         <input type="text" id="joinRoomCode" placeholder="Código" class="room-code-input" maxlength="6">
-                        <button onclick="joinRoom()" class="btn-secondary" id="joinRoomBtn" disabled>
+                        <button type="button" onclick="joinRoom()" class="btn-secondary" id="joinRoomBtn" disabled>
                             Unirse
                         </button>
                     </div>
                 `;
             } else if (mode === 'practice') {
                 buttonsDiv.innerHTML = `
-                    <button onclick="startPractice()" class="btn-primary btn-large" id="startPracticeBtn" disabled>
+                    <button type="button" onclick="startPractice()" class="btn-primary btn-large" id="startPracticeBtn" disabled>
                         🎯 Iniciar Práctica
                     </button>
                 `;
@@ -991,7 +1022,7 @@
                 buttonsDiv.innerHTML = `
                     <div class="join-room-group">
                         <input type="text" id="tournamentId" placeholder="ID de torneo" class="room-code-input">
-                        <button onclick="joinTournamentMode()" class="btn-primary" id="joinTournamentBtn" disabled>
+                        <button type="button" onclick="joinTournamentMode()" class="btn-primary" id="joinTournamentBtn" disabled>
                             🏆 Unirme
                         </button>
                     </div>


### PR DESCRIPTION
### Motivation
- Users reported repeated `ReferenceError: selectMode is not defined` and a SyntaxError causing the mode buttons to be non-functional when later scripts fail to load or parse. 
- The intent is to ensure the mode selector UI remains usable even if downstream JS is missing or broken. 
- Also reduce accidental form submits and cross-browser inconsistencies by making inline action elements explicit buttons.

### Description
- Added an early, defensive global fallback for `selectMode` and `backToModes` in the head bootstrap inline script so clicks on mode cards/buttons never cause a `ReferenceError` and still show the song-selection flow. 
- Hardened many interactive controls by adding `type="button"` to injected and static buttons and removed reliance on an implicit `event` in the mode card handlers (replaced `event.stopPropagation(); selectMode(...)` with direct `selectMode(...)`). 
- Ensured dynamically-generated action button markup in `updateActionButtons` and `renderWalletDirectory` includes `type="button"` so injected buttons behave consistently.

### Testing
- Ran `npm run check` which completed successfully and reported `runtime-integrity-ok`. 
- Validated all inline scripts parse by executing them with `new Function(...)` (all inline scripts returned OK). 
- Attempted browser E2E/screenshot with Playwright but the environment failed to start/connect to the browser (network/port error), so no browser artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b5605eb54832db7a4ec24b3793469)