### PR TITLE
Fix dashboard buttons by removing merge artifacts and duplicate script tags in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,26 +639,14 @@
     <script src="./auth-system.js"></script>
     <script src="./game-engine.js"></script>
     <script>window.MTR_INLINE_TOP_STREAMS_ACTIVE = true;</script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
     <script src="./app.js?v=20260222b"></script>
     <script src="./top-streams-fallback.js?v=20260222b"></script>
-
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
-    <script src="./app.js?v=20260222a"></script>
-    <script src="./top-streams-fallback.js?v=20260222a"></script>
-
-    <script src="./app.js?v=20260217e"></script>
-    <script src="./top-streams-fallback.js?v=20260217e"></script>
- feature/wall-street-v2
- feature/wall-street-v2
 
 
 
 
     <script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
 
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
 
         // Dashboard inline fallback removed; using top-streams-fallback.js
 
@@ -822,8 +810,6 @@
 
             });
         })();
- feature/wall-street-v2
- feature/wall-street-v2
         // Variables globales
         let selectedSong = null;
         let currentMode = null;


### PR DESCRIPTION
### Motivation
- Merge artifacts and stray branch-name text were injected into the `<script>` area of `index.html`, causing inline script parse issues and interfering with global handlers (e.g. `onclick` for dashboard buttons and region tabs). 
- Multiple duplicated `app.js` / `top-streams-fallback.js` includes caused duplicate bootstrap execution and risked breaking event handlers. 

### Description
- Removed stray branch-artifact lines and garbage text surrounding the scripts block in `index.html` so the script section is valid again. 
- Eliminated duplicated legacy script tags so only the latest builds (`app.js?v=20260222b` and `top-streams-fallback.js?v=20260222b`) are loaded. 
- Cleaned up the inline dashboard fallback area to avoid injected text interfering with DOM bootstrapping and carousel/tab handlers. 

### Testing
- Ran `npm run check` which runs `node --check` across JS files and `scripts/verify-runtime-integrity.js`, and it completed successfully (`runtime-integrity-ok`).
- Verified removal of artifacts with ripgrep checks (`rg -n "codex/|feature/wall-street|20260222a|20260217e"` and `rg -n "<<<<<<<|>>>>>>>|=====" index.html`) and found no remaining merge markers. 
- Attempted automated UI validation via serving the site with `python3 -m http.server` and capturing a screenshot with Playwright, but the Playwright run timed out in this environment despite the server responding to asset requests (screenshot generation failed due to timeout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bcc957244832d88a72a034f86e057)