### PR TITLE
Hotfix: avoid dashboard freeze by skipping inline fallback when JS fallback active

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,31 +639,23 @@
     <script src="./auth-system.js"></script>
     <script src="./game-engine.js"></script>
     <script>window.MTR_INLINE_TOP_STREAMS_ACTIVE = true;</script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
     <script src="./app.js?v=20260222b"></script>
     <script src="./top-streams-fallback.js?v=20260222b"></script>
-
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
-    <script src="./app.js?v=20260222a"></script>
-    <script src="./top-streams-fallback.js?v=20260222a"></script>
-
-    <script src="./app.js?v=20260217e"></script>
-    <script src="./top-streams-fallback.js?v=20260217e"></script>
- feature/wall-street-v2
- feature/wall-street-v2
 
 
 
 
     <script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
 
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
 
         // Dashboard inline fallback removed; using top-streams-fallback.js
 
 
         (function () {
+            if (window.MTR_INLINE_TOP_STREAMS_ACTIVE) {
+                return;
+            }
+
             var dashboardRegion = 'latam';
             var dashboardOffset = 0;
 
@@ -822,8 +814,6 @@
 
             });
         })();
- feature/wall-street-v2
- feature/wall-street-v2
         // Variables globales
         let selectedSong = null;
         let currentMode = null;


### PR DESCRIPTION
### Motivation
- Prevent the page freeze caused by duplicate dashboard bootstraps (inline IIFE running at the same time as `top-streams-fallback.js`) while keeping changes off `main` by working on a new hotfix branch.

### Description
- Add an early-return guard at the start of the inline dashboard IIFE in `index.html` that returns immediately when `window.MTR_INLINE_TOP_STREAMS_ACTIVE` is true, preventing the inline fallback from running alongside the JS fallback.

### Testing
- Ran `npm run check` which reported `runtime-integrity-ok`, served the site with `python3 -m http.server` and confirmed assets returned HTTP 200, and captured a Playwright screenshot after loading `index.html` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bcc957244832d88a72a034f86e057)