### PR TITLE
Add runtime safety checkpoint to protect working dashboard bootstrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,31 +639,23 @@
     <script src="./auth-system.js"></script>
     <script src="./game-engine.js"></script>
     <script>window.MTR_INLINE_TOP_STREAMS_ACTIVE = true;</script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
     <script src="./app.js?v=20260222b"></script>
     <script src="./top-streams-fallback.js?v=20260222b"></script>
-
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
-    <script src="./app.js?v=20260222a"></script>
-    <script src="./top-streams-fallback.js?v=20260222a"></script>
-
-    <script src="./app.js?v=20260217e"></script>
-    <script src="./top-streams-fallback.js?v=20260217e"></script>
- feature/wall-street-v2
- feature/wall-street-v2
 
 
 
 
     <script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
 
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
 
         // Dashboard inline fallback removed; using top-streams-fallback.js
 
 
         (function () {
+            if (window.MTR_INLINE_TOP_STREAMS_ACTIVE) {
+                return;
+            }
+
             var dashboardRegion = 'latam';
             var dashboardOffset = 0;
 
@@ -822,8 +814,6 @@
 
             });
         })();
- feature/wall-street-v2
- feature/wall-street-v2
         // Variables globales
         let selectedSong = null;
         let currentMode = null;

--- a/scripts/verify-runtime-integrity.js
+++ b/scripts/verify-runtime-integrity.js
@@ -43,6 +43,19 @@ if (topRefs.length !== 1) {
   failed = true;
 }
 
+
+const inlineTopStreamsFlagRefs = [...indexHtml.matchAll(/window\.MTR_INLINE_TOP_STREAMS_ACTIVE\s*=\s*true/gi)];
+if (inlineTopStreamsFlagRefs.length !== 1) {
+  console.error('INVALID_INLINE_TOP_STREAMS_FLAG_COUNT', inlineTopStreamsFlagRefs.length);
+  failed = true;
+}
+
+const hasInlineDashboardGuard = /if\s*\(\s*window\.MTR_INLINE_TOP_STREAMS_ACTIVE\s*\)\s*\{\s*return;\s*\}/m.test(indexHtml);
+if (!hasInlineDashboardGuard) {
+  console.error('MISSING_INLINE_DASHBOARD_GUARD', 'Expected inline fallback early-return guard in index.html');
+  failed = true;
+}
+
 if (/src\/app\.js\?v=/i.test(indexHtml) || /src\/top-streams-fallback\.js\?v=/i.test(indexHtml)) {
   console.error('INVALID_SRC_RUNTIME_INCLUDE', 'Legacy /src runtime include found in index.html');
   failed = true;


### PR DESCRIPTION
### Motivation
- Prevent accidental regressions that re-enable the removed inline dashboard bootstrap or introduce duplicate bootstraps or merge artifacts that break the live dashboard.
- Provide a clear automated checkpoint so future edits fail fast when the dashboard bootstrap invariants are violated.

### Description
- Added stricter runtime checks to `scripts/verify-runtime-integrity.js` that assert there is exactly one `window.MTR_INLINE_TOP_STREAMS_ACTIVE = true` occurrence and that the inline early-return guard exists.
- Added an inline guard to the dashboard bootstrap that returns early when `window.MTR_INLINE_TOP_STREAMS_ACTIVE` is true via `if (window.MTR_INLINE_TOP_STREAMS_ACTIVE) { return; }` in `index.html`.
- Left existing script include and blocked-pattern checks intact so the integrity script continues to validate other runtime invariants.

### Testing
- Ran `npm run check` (which runs `node --check` on runtime files and `scripts/verify-runtime-integrity.js`) and it completed successfully with `runtime-integrity-ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bcc957244832d88a72a034f86e057)