### PR TITLE
Fix false 'Backend API no configurada' during deposit verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,52 @@
 
 Frontend completo para la plataforma de batallas musicales con blockchain.
 
+## 📘 Manual de uso (usuario final)
+
+Esta sección es una guía rápida para cualquier usuario que quiera usar la app sin entrar en detalles técnicos.
+
+### 1) Entrar a la app
+- Abre la URL del frontend en tu navegador.
+- Espera a que cargue el dashboard principal (cards de streams y secciones de juego).
+
+### 2) Conectar wallet
+- Haz clic en **Connect Wallet**.
+- Autoriza la conexión en MetaMask (u otra wallet compatible).
+- Verifica que aparezca tu dirección y/o balance en pantalla.
+
+### 3) Recargar saldo (depósito verificable)
+- Realiza la transferencia on-chain a la wallet/plataforma indicada.
+- Copia el `txHash` de tu transacción.
+- En la app, pega el `txHash` y ejecuta **Verify Deposit**.
+- Si la validación es correcta, verás tu saldo actualizado.
+
+### 4) Participar en modos de juego
+- Selecciona el modo deseado (por ejemplo: quick, private o tournament).
+- Elige tracks/participación según el flujo de ese modo.
+- Confirma los pasos solicitados por la interfaz para iniciar.
+
+### 5) Revisar dashboard de streams
+- Cambia entre regiones/pestañas del dashboard.
+- Usa las flechas del carrusel para navegar cards.
+- Confirma que los datos se refrescan sin congelarse.
+
+### 6) Retirar ganancias (cashout)
+- Ve a la sección de retiro.
+- Usa **Quote Cashout** para cotizar fee y monto neto.
+- Si estás de acuerdo, confirma con **Request Cashout**.
+- Guarda el identificador de solicitud para seguimiento.
+
+### 7) Buenas prácticas para evitar errores
+- No abras varias sesiones con la misma wallet en muchas pestañas a la vez.
+- Si algo no responde, recarga la página una vez y vuelve a intentar.
+- Si persiste, abre consola (F12) y comparte el error con soporte.
+
+### Checklist rápido de funcionamiento
+- ✅ Conecta wallet.
+- ✅ Verifica depósito con `txHash`.
+- ✅ Navega dashboard (tabs + carrusel).
+- ✅ Genera cotización y solicitud de cashout.
+
 ## 📁 Estructura del Proyecto
 
 ```

--- a/game-engine.js
+++ b/game-engine.js
@@ -1556,9 +1556,9 @@ const GameEngine = {
     // ==========================================
 
     getBackendApiBase() {
-        if (window.CONFIG?.BACKEND_API) return window.CONFIG.BACKEND_API;
-        if (window.APP_BACKEND_API) return window.APP_BACKEND_API;
-        return '';
+        const runtimeConfig = window.CONFIG || (typeof CONFIG !== 'undefined' ? CONFIG : null);
+        const configuredBase = runtimeConfig?.BACKEND_API || window.APP_BACKEND_API || '';
+        return String(configuredBase || '').trim().replace(/\/$/, '');
     },
 
     async backendRequest(path, payload = {}) {

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
             BATTLE_DURATION: 60,
             BACKEND_API: 'https://musictoken-backend.onrender.com'
         };
+        window.CONFIG = CONFIG;
         function extractMetaMaskErrorMessage(reason) {
             if (!reason) return '';
             const direct = String(reason?.message || reason || '');
@@ -639,31 +640,23 @@
     <script src="./auth-system.js"></script>
     <script src="./game-engine.js"></script>
     <script>window.MTR_INLINE_TOP_STREAMS_ACTIVE = true;</script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
     <script src="./app.js?v=20260222b"></script>
     <script src="./top-streams-fallback.js?v=20260222b"></script>
-
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
-    <script src="./app.js?v=20260222a"></script>
-    <script src="./top-streams-fallback.js?v=20260222a"></script>
-
-    <script src="./app.js?v=20260217e"></script>
-    <script src="./top-streams-fallback.js?v=20260217e"></script>
- feature/wall-street-v2
- feature/wall-street-v2
 
 
 
 
     <script>
- codex/fix-code-issues-and-reverse-broken-merges-tmxnpe
 
- codex/fix-code-issues-and-reverse-broken-merges-7wull6
 
         // Dashboard inline fallback removed; using top-streams-fallback.js
 
 
         (function () {
+            if (window.MTR_INLINE_TOP_STREAMS_ACTIVE) {
+                return;
+            }
+
             var dashboardRegion = 'latam';
             var dashboardOffset = 0;
 
@@ -822,8 +815,6 @@
 
             });
         })();
- feature/wall-street-v2
- feature/wall-street-v2
         // Variables globales
         let selectedSong = null;
         let currentMode = null;

--- a/scripts/verify-runtime-integrity.js
+++ b/scripts/verify-runtime-integrity.js
@@ -43,6 +43,19 @@ if (topRefs.length !== 1) {
   failed = true;
 }
 
+
+const inlineTopStreamsFlagRefs = [...indexHtml.matchAll(/window\.MTR_INLINE_TOP_STREAMS_ACTIVE\s*=\s*true/gi)];
+if (inlineTopStreamsFlagRefs.length !== 1) {
+  console.error('INVALID_INLINE_TOP_STREAMS_FLAG_COUNT', inlineTopStreamsFlagRefs.length);
+  failed = true;
+}
+
+const hasInlineDashboardGuard = /if\s*\(\s*window\.MTR_INLINE_TOP_STREAMS_ACTIVE\s*\)\s*\{\s*return;\s*\}/m.test(indexHtml);
+if (!hasInlineDashboardGuard) {
+  console.error('MISSING_INLINE_DASHBOARD_GUARD', 'Expected inline fallback early-return guard in index.html');
+  failed = true;
+}
+
 if (/src\/app\.js\?v=/i.test(indexHtml) || /src\/top-streams-fallback\.js\?v=/i.test(indexHtml)) {
   console.error('INVALID_SRC_RUNTIME_INCLUDE', 'Legacy /src runtime include found in index.html');
   failed = true;


### PR DESCRIPTION
### Motivation
- Users reported a `Backend API no configurada` error when clicking **Verificar y acreditar recarga** even though `BACKEND_API` was present in the page configuration. 
- The frontend only looked for `window.CONFIG.BACKEND_API` while `index.html` declared a lexical `const CONFIG`, so the runtime lookup failed and produced a misleading UI error. 
- The repo also had fragile inline dashboard fallback logic and some leftover merge artifacts that could break runtime integrity checks.

### Description
- Exposed runtime configuration by assigning `window.CONFIG = CONFIG` in `index.html` so runtime code can reliably read `BACKEND_API`.
- Hardened `getBackendApiBase()` in `game-engine.js` to prefer `window.CONFIG`, fall back to a lexical `CONFIG` if present, then to `window.APP_BACKEND_API`, and normalize the result by trimming and removing a trailing slash.
- Added an early-return guard in the inline dashboard fallback in `index.html` and removed stray merge-artifact lines to keep script includes deterministic.
- Extended `scripts/verify-runtime-integrity.js` with checks for the inline top-streams flag and the expected early-return guard to prevent regressions.

### Testing
- Ran `npm run check` and the runtime integrity script completed successfully reporting `runtime-integrity-ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bcc957244832d88a72a034f86e057)