### PR TITLE
feat: migrate MTR flow to Base + wagmi wallet connection

### DIFF
--- a/auth-system.js
+++ b/auth-system.js
@@ -307,13 +307,13 @@ async function loadPlayerProfile(user) {
             return;
         }
 
-        setProfileValue('profileBalance', `${Math.round(balanceData?.balance || 0)} $MTOKEN`);
+        setProfileValue('profileBalance', `${Math.round(balanceData?.balance || 0)} MTR`);
         setProfileValue('profileMatches', `${totalMatches}`);
         setProfileValue('profileWins', `${wins}`);
         setProfileValue('profileLosses', `${losses}`);
         setProfileValue('profileWinRate', `${winRate}%`);
         setProfileValue('profileStreams', `${Math.round(totalStreams).toLocaleString('es-ES')}`);
-        setProfileValue('profileWagered', `${Math.round(totalWagered)} $MTOKEN`);
+        setProfileValue('profileWagered', `${Math.round(totalWagered)} MTR`);
 
         const recentMatches = document.getElementById('profileRecentMatches');
         if (recentMatches) {
@@ -327,7 +327,7 @@ async function loadPlayerProfile(user) {
                     const ownBet = isP1 ? (m.player1_bet || 0) : (m.player2_bet || 0);
                     return `<div class="profile-match ${won ? 'win' : 'loss'}">
                         <span>${won ? '✅ Victoria' : '❌ Derrota'} · ${mode}</span>
-                        <span>${ownBet} $MTOKEN</span>
+                        <span>${ownBet} MTR</span>
                     </div>`;
                 }).join('');
             }

--- a/backend/prize-service.js
+++ b/backend/prize-service.js
@@ -1,0 +1,51 @@
+/**
+ * Servicio backend para enviar premios MTR en Base.
+ * Usa variables de entorno (no hardcodear claves privadas).
+ */
+const { createPublicClient, createWalletClient, http, parseUnits } = require('viem');
+const { privateKeyToAccount } = require('viem/accounts');
+const { base } = require('viem/chains');
+
+const MTR_TOKEN_ADDRESS = '0x99cd1eb32846c9027ed9cb88710066fa08791c33b';
+const ERC20_ABI = [
+  {
+    type: 'function',
+    name: 'transfer',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' }
+    ],
+    outputs: [{ name: '', type: 'bool' }]
+  }
+];
+
+async function sendPrize(winner, amount) {
+  const rpcUrl = process.env.BASE_RPC_URL || 'https://mainnet.base.org';
+  const privateKey = process.env.PRIZE_SIGNER_PRIVATE_KEY;
+
+  if (!privateKey) {
+    throw new Error('Missing PRIZE_SIGNER_PRIVATE_KEY env var');
+  }
+
+  const account = privateKeyToAccount(privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`);
+  const publicClient = createPublicClient({ chain: base, transport: http(rpcUrl) });
+  const walletClient = createWalletClient({ account, chain: base, transport: http(rpcUrl) });
+
+  const value = parseUnits(String(amount), 18);
+  console.log('[prize] sendPrize start', { winner, amount, value: value.toString() });
+
+  const hash = await walletClient.writeContract({
+    address: MTR_TOKEN_ADDRESS,
+    abi: ERC20_ABI,
+    functionName: 'transfer',
+    args: [winner, value]
+  });
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+  console.log('[prize] sendPrize confirmed', { hash, status: receipt.status });
+
+  return { txHash: hash, status: receipt.status };
+}
+
+module.exports = { sendPrize };

--- a/config/config.js
+++ b/config/config.js
@@ -4,15 +4,15 @@ const CONFIG = {
     BACKEND_API: 'http://localhost:3000',  // CAMBIAR EN PRODUCCIÓN
     
     // Blockchain Configuration
-    CHAIN_ID: 80001,  // Mumbai testnet (cambiar a 137 para Polygon mainnet)
-    RPC_URL: 'https://polygon-mumbai.g.alchemy.com/v2/YOUR_ALCHEMY_KEY',
+    CHAIN_ID: 8453,  // Base Mainnet
+    RPC_URL: 'https://mainnet.base.org',
     
     // Smart Contracts (actualizar después del deploy)
     CONTRACT_ADDRESS: '0xYourBattleContractAddress',
-    TOKEN_ADDRESS: '0xYourTokenContractAddress',
+    TOKEN_ADDRESS: '0x99cd1eb32846c9027ed9cb88710066fa08791c33b',
     
     // App Configuration
     BATTLE_DURATION: 60,  // segundos
     BURN_RATE: 0.005,     // 0.5%
-    MAX_BET: 10000,       // $MTOKEN
+    MAX_BET: 10000,       // MTR
 }

--- a/game-engine.js
+++ b/game-engine.js
@@ -21,6 +21,7 @@ const GameEngine = {
     userAudio: null,
     victoryAudio: null,
     connectedWallet: null,
+    lastPrizeTxHash: null,
     quickMatchChannel: null,
     pendingChallenge: null,
     currentRoomCode: null,
@@ -151,7 +152,7 @@ const GameEngine = {
     updateBalanceDisplay() {
         const balanceEl = document.getElementById('balanceDisplay');
         if (balanceEl) {
-            balanceEl.textContent = `💰 ${this.userBalance} $MTOKEN`;
+            balanceEl.textContent = `💰 ${this.userBalance} MTR`;
         }
         const userBalanceEl = document.getElementById('userBalance');
         if (userBalanceEl) {
@@ -166,7 +167,7 @@ const GameEngine = {
     
     async joinQuickMatch(song, betAmount) {
         if (betAmount < this.minBet) {
-            showToast(`Apuesta mínima: ${this.minBet} $MTOKEN`, 'error');
+            showToast(`Apuesta mínima: ${this.minBet} MTR`, 'error');
             return;
         }
         
@@ -284,7 +285,7 @@ const GameEngine = {
         const challenge = this.pendingChallenge;
         if (!challenge) return;
         if (betAmount < challenge.betAmount) {
-            showToast(`La apuesta debe ser mínimo ${challenge.betAmount} $MTOKEN`, 'error');
+            showToast(`La apuesta debe ser mínimo ${challenge.betAmount} MTR`, 'error');
             return;
         }
         this.pendingChallenge = null;
@@ -458,7 +459,7 @@ const GameEngine = {
             }
             
             if (betAmount < match.player1_bet) {
-                showToast(`Apuesta mínima de la sala: ${match.player1_bet} $MTOKEN`, 'error');
+                showToast(`Apuesta mínima de la sala: ${match.player1_bet} MTR`, 'error');
                 return;
             }
             
@@ -568,7 +569,7 @@ const GameEngine = {
 
             const normalizedBet = Math.max(this.minBet, Math.round(demoBet || this.minBet));
             if (normalizedBet > this.practiceDemoBalance) {
-                showToast(`Saldo demo insuficiente. Disponible: ${this.practiceDemoBalance} $MTOKEN`, 'error');
+                showToast(`Saldo demo insuficiente. Disponible: ${this.practiceDemoBalance} MTR`, 'error');
                 return;
             }
 
@@ -602,7 +603,7 @@ const GameEngine = {
             
             if (error) throw error;
             
-            showToast(`¡Iniciando práctica con ${normalizedBet} $MTOKEN demo!`, 'success');
+            showToast(`¡Iniciando práctica con ${normalizedBet} MTR demo!`, 'success');
             await this.startMatch(match.id);
             
         } catch (error) {
@@ -655,7 +656,7 @@ const GameEngine = {
                 .single();
             
             if (betAmount < tournament.entry_fee) {
-                showToast(`Entry fee: ${tournament.entry_fee} $MTOKEN`, 'error');
+                showToast(`Entry fee: ${tournament.entry_fee} MTR`, 'error');
                 return;
             }
             
@@ -792,7 +793,7 @@ const GameEngine = {
                             </div>
                         </div>
                         <div class="battle-plays">🎧 Reproducciones: <span id="plays1">0</span></div>
-                        <div class="battle-bet">💰 ${match.player1_bet} $MTOKEN</div>
+                        <div class="battle-bet">💰 ${match.player1_bet} MTR</div>
                     </div>
                     
                     <!-- VS -->
@@ -837,7 +838,7 @@ const GameEngine = {
                             </div>
                         </div>
                         <div class="battle-plays">🎧 Reproducciones: <span id="plays2">0</span></div>
-                        <div class="battle-bet">💰 ${match.player2_bet} $MTOKEN</div>
+                        <div class="battle-bet">💰 ${match.player2_bet} MTR</div>
                     </div>
                 </div>
             </section>
@@ -1029,6 +1030,10 @@ const GameEngine = {
         if (match.match_type !== 'practice') {
             if (userWon) {
                 await this.updateBalance(payouts.winnerPayout, 'win', match.id);
+                const winnerWallet = this.connectedWallet || localStorage.getItem('mtr_wallet') || null;
+                if (winnerWallet) {
+                    await this.sendPrizeToWinner(winnerWallet, payouts.winnerPayout, match.id);
+                }
             }
             this.addToPlatformRevenue(payouts.platformFee);
             await this.logPlatformFeeTransaction(match.id, payouts.platformFee);
@@ -1050,7 +1055,7 @@ const GameEngine = {
         const winnerName = winner === 1 ? match.player1_song_name : match.player2_song_name;
         const prize = userWon ? payouts.winnerPayout : 0;
         const platformWallet = this.getPlatformWalletAddress();
-        const payoutNetwork = this.getPreferredNetwork();
+        const payoutNetwork = 'base';
         
         const container = document.querySelector('.container');
         container.innerHTML = `
@@ -1058,15 +1063,16 @@ const GameEngine = {
                 <div class="victory-icon">${userWon ? '🏆' : '😔'}</div>
                 <h1 class="victory-title">${userWon ? '¡VICTORIA!' : 'Derrota'}</h1>
                 <h2 class="victory-winner">${winnerName}</h2>
-                ${prize > 0 ? `<p class="victory-prize">+${prize} $MTOKEN</p>` : ''}
+                ${prize > 0 ? `<p class="victory-prize">+${prize} MTR</p>` : ''}
                 ${match.match_type !== 'practice' ? `
                     <div class="victory-breakdown">
-                        <p>Comisión plataforma: ${payouts.platformFee} $MTOKEN</p>
-                        <p>Pago al ganador: ${payouts.winnerPayout} $MTOKEN</p>
+                        <p>Comisión plataforma: ${payouts.platformFee} MTR</p>
+                        <p>Pago al ganador: ${payouts.winnerPayout} MTR</p>
                         <p>Red de cobro: ${payoutNetwork.toUpperCase()}</p>
                         <p>Billetera plataforma: ${platformWallet}</p>
                     </div>
                 ` : ''}
+                ${this.lastPrizeTxHash ? `<p class="victory-prize">✅ Premio enviado! Tx: <a href="https://basescan.org/tx/${this.lastPrizeTxHash}" target="_blank" rel="noopener noreferrer">Ver en Basescan</a></p>` : ''}
                 <button onclick="${match.match_type === 'practice' ? 'GameEngine.goToPracticeSelection()' : 'location.reload()'}" class="btn-primary btn-large">
                     ${match.match_type === 'practice' ? 'Continuar en práctica' : 'Jugar de Nuevo'}
                 </button>
@@ -1295,6 +1301,7 @@ const GameEngine = {
             return;
         }
         try {
+            console.log('[wallet] connectWallet() request');
             const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
             const chainIdHex = await window.ethereum.request({ method: 'eth_chainId' });
             const chainId = Number.parseInt(chainIdHex, 16);
@@ -1303,6 +1310,7 @@ const GameEngine = {
                 localStorage.setItem('mtr_wallet', accounts[0]);
                 localStorage.setItem('mtr_wallet_chain', this.getChainNameFromId(chainId));
                 this.updateWalletDisplay();
+                console.log('[wallet] connected', { address: accounts[0], chainId });
                 showToast('Wallet conectada', 'success');
             }
         } catch (error) {
@@ -1323,14 +1331,12 @@ const GameEngine = {
             1: 'ethereum',
             10: 'optimism',
             56: 'bnb',
-            137: 'polygon',
             42161: 'arbitrum',
             59144: 'linea',
             8453: 'base',
-            80001: 'polygon',
             11155111: 'ethereum'
         };
-        return map[chainId] || 'polygon';
+        return map[chainId] || 'base';
     },
 
 
@@ -1339,19 +1345,18 @@ const GameEngine = {
         if (configured) return configured;
 
         const connectedChain = localStorage.getItem('mtr_wallet_chain');
-        if (connectedChain) return connectedChain;
+        if (connectedChain === 'base') return connectedChain;
 
-        return 'polygon';
+        return 'base';
     },
 
     getPlatformWalletAddress() {
         const addresses = window.PLATFORM_WALLET_ADDRESSES || {};
         const preferredOrder = [
             this.getPreferredNetwork(),
-            'polygon',
+            'base',
             'ethereum',
             'optimism',
-            'base',
             'arbitrum',
             'bnb',
             'linea',
@@ -1629,7 +1634,7 @@ const GameEngine = {
         try {
             const data = await this.backendRequest('/api/deposits/verify', {
                 txHash,
-                network: options.network || this.getPreferredNetwork(),
+                network: options.network || 'base',
                 expectedAmount: options.expectedAmount || null,
                 walletAddress: this.connectedWallet || localStorage.getItem('mtr_wallet') || null
             });
@@ -1655,7 +1660,7 @@ const GameEngine = {
         try {
             const data = await this.backendRequest('/api/settlement/quote', {
                 tokenAmount,
-                network: this.getPreferredNetwork()
+                network: 'base'
             });
             return data;
         } catch (error) {
@@ -1674,7 +1679,7 @@ const GameEngine = {
         try {
             const data = await this.backendRequest('/api/settlement/request-cashout', {
                 tokenAmount,
-                network: options.network || this.getPreferredNetwork(),
+                network: options.network || 'base',
                 walletAddress: this.connectedWallet || localStorage.getItem('mtr_wallet') || null,
                 stableCurrency: 'USDs'
             });
@@ -1692,6 +1697,27 @@ const GameEngine = {
         } catch (error) {
             console.error('Error requesting cashout:', error);
             showToast('No se pudo solicitar el retiro', 'error');
+            return null;
+        }
+    },
+
+    async sendPrizeToWinner(winnerAddress, amountMtr, matchId = null) {
+        if (!winnerAddress || !amountMtr) return null;
+        try {
+            console.log('[prize] Sending prize request to backend', { winnerAddress, amountMtr, matchId });
+            const data = await this.backendRequest('/api/prizes/send', {
+                winner: winnerAddress,
+                amount: amountMtr,
+                matchId,
+                network: 'base'
+            });
+            if (data?.txHash) {
+                this.lastPrizeTxHash = data.txHash;
+                console.log('[prize] Prize tx hash', data.txHash);
+            }
+            return data;
+        } catch (error) {
+            console.error('[prize] Error sending prize:', error);
             return null;
         }
     },

--- a/index.html
+++ b/index.html
@@ -52,16 +52,7 @@
         });
 
         const PLATFORM_WALLET_ADDRESSES = {
-            polygon: '0x75376BC58830f27415402875D26B73A6BE8E2253',
-            optimism: '0x75376BC58830f27415402875D26B73A6BE8E2253',
-            base: '0x75376BC58830f27415402875D26B73A6BE8E2253',
-            bnb: '0x75376BC58830f27415402875D26B73A6BE8E2253',
-            arbitrum: '0x75376BC58830f27415402875D26B73A6BE8E2253',
-            linea: '0x75376BC58830f27415402875D26B73A6BE8E2253',
-            ethereum: '0x75376BC58830f27415402875D26B73A6BE8E2253',
-            tron: 'TQMKLv12VA2kt2xH1edWNnQjgFGuzaLcVj',
-            solana: 'AavRs1c4CmBDcJ2KzTh5C8btwbLv7CnCRbA6EpEJqaNr',
-            bitcoin: 'bc1qtjwwj5lwsn4r5pjg8l30r4s5p843g4p344tr6a'
+            base: '0x75376BC58830f27415402875D26B73A6BE8E2253'
         };
         window.MTR_BUILD_ID = '20260222c';
 
@@ -112,12 +103,12 @@
                 <div class="header-badges">
                     <span class="badge">🎵 Deezer</span>
                     <span class="badge badge-live">🔴 Live</span>
-                    <span class="badge" id="balanceDisplay">💰 0 $MTOKEN</span>
+                    <span class="badge" id="balanceDisplay">Tu MTR: --</span>
                 </div>
 
                 <div class="wallet-section">
-                    <button type="button" onclick="connectWallet()" class="btn-secondary btn-wallet">
-                        🦊 Conectar Wallet
+                    <button type="button" id="walletConnectBtn" class="btn-secondary btn-wallet">
+                        Conectar Wallet
                     </button>
                     <span id="walletAddress" class="wallet-address hidden"></span>
                 </div>
@@ -183,7 +174,7 @@
                     <div class="login-wall-icon">🥊</div>
                     <h1 class="login-wall-title">Bienvenido a MusicToken Ring</h1>
                     <p class="login-wall-subtitle">
-                        Batalla con tus canciones favoritas, apuesta $MTOKEN y demuestra quién tiene mejor gusto musical
+                        Batalla con tus canciones favoritas, apuesta MTR y demuestra quién tiene mejor gusto musical
                     </p>
                     <button type="button" onclick="openAuthModal()" class="btn-primary btn-large">
                         Iniciar Sesión para Jugar
@@ -223,14 +214,13 @@
             </section>
 
             <section class="payments-showcase">
-                <p class="streaming-label">Redes y monedas soportadas para pagos</p>
+                <p class="streaming-label">Pagos en Base con MTR</p>
                 <div class="payment-controls">
-                    <label for="preferredNetwork" class="payment-label">Red preferida para comisiones</label>
+                    <label for="preferredNetwork" class="payment-label">Red Base para pagos</label>
                     <select id="preferredNetwork" class="payment-select" onchange="setPreferredNetwork(this.value)"></select>
                 </div>
                 <div class="currency-logos">
-                    <img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/polygon.svg" alt="Polygon" class="currency-logo" onerror="this.style.display='none'">
-                    <img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/ethereum.svg" alt="Ethereum" class="currency-logo" onerror="this.style.display='none'">
+                                        <img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/ethereum.svg" alt="Ethereum" class="currency-logo" onerror="this.style.display='none'">
                     <img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/optimism.svg" alt="Optimism" class="currency-logo" onerror="this.style.display='none'">
                     <img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/base.svg" alt="Base" class="currency-logo" onerror="this.style.display='none'">
                     <img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/bnbchain.svg" alt="BNB Chain" class="currency-logo" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/binance.svg';">
@@ -244,29 +234,38 @@
 
                 <div class="settlement-panel">
                     <div class="settlement-card">
-                        <h4>Recarga verificable (on-chain → saldo)</h4>
+                        <h4>Comprar MTR directo</h4>
                         <p class="settlement-help">
-                            Envía tus tokens a la wallet de la red seleccionada y pega el hash de transacción para validarlo con el backend.
+                            Compra MTR en Aerodrome y vuelve aquí: el saldo se actualiza automáticamente al conectar tu wallet en Base.
                         </p>
                         <div class="settlement-grid">
-                            <input id="depositTxHash" class="payment-input" type="text" placeholder="0x... hash de transacción">
-                            <input id="depositAmount" class="payment-input" type="number" min="1" placeholder="Monto enviado (opcional)">
+                            <a class="btn-primary" target="_blank" rel="noopener noreferrer" href="https://aerodrome.finance/swap?from=ETH&to=0x99cd1eb32846c9027ed9cb88710066fa08791c33b">Comprar MTR en Aerodrome</a>
+                            <p class="settlement-help">Contrato MTR: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb88710066fa08791c33b">0x99cd1eb32846c9027ed9cb88710066fa08791c33b</a></p>
                         </div>
-                        <button type="button" class="btn-secondary" onclick="verifyDepositTx()">✅ Verificar y acreditar recarga</button>
+                        
                     </div>
 
                     <div class="settlement-card">
-                        <h4>Liquidación de ganancias (MTOKEN → USD digital)</h4>
+                        <h4>Liquidación de ganancias (MTR → USD digital)</h4>
                         <p class="settlement-help">
                             Solicita retiro cuando tengas saldo. El backend cotiza con referencia USD y registra la comisión antes de liquidar.
                         </p>
                         <div class="settlement-grid">
-                            <input id="cashoutAmount" class="payment-input" type="number" min="1" placeholder="MTOKEN a retirar">
+                            <input id="cashoutAmount" class="payment-input" type="number" min="1" placeholder="MTR a retirar">
                             <button type="button" class="btn-secondary" onclick="quoteCashout()">📊 Cotizar en USD</button>
                         </div>
                         <p class="settlement-quote" id="cashoutQuote">Sin cotización aún.</p>
                         <button type="button" class="btn-primary" onclick="requestCashout()">💸 Solicitar retiro</button>
                     </div>
+                </div>
+            </section>
+
+            <section class="payments-showcase">
+                <p class="streaming-label">Sobre MTR</p>
+                <div class="settlement-card">
+                    <p>Token ERC-20 en Base. Liquidez lockeada en Aerodrome.</p>
+                    <p>Contrato: 0x99cd1eb32846c9027ed9cb88710066fa08791c33b.</p>
+                    <p>Explorer: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb88710066fa08791c33b">https://basescan.org/address/0x99cd1eb32846c9027ed9cb88710066fa08791c33b</a></p>
                 </div>
             </section>
 
@@ -378,8 +377,8 @@
                         <div class="bet-section">
                             <h3>💰 Tu Apuesta</h3>
                             <div class="bet-info">
-                                <span><span id="balanceLabel">Balance</span>: <strong id="userBalance">0</strong> $MTOKEN</span>
-                                <span>Mínimo: <strong id="minBet">100</strong> $MTOKEN</span>
+                                <span><span id="balanceLabel">Tu MTR</span>: <strong id="userBalance">0</strong> MTR</span>
+                                <span>Mínimo: <strong id="minBet">100</strong> MTR</span>
                             </div>
                             <input 
                                 type="number" 
@@ -603,7 +602,7 @@
                 <div class="profile-stat-card"><span>Derrotas</span><strong id="profileLosses">-</strong></div>
                 <div class="profile-stat-card"><span>Win Rate</span><strong id="profileWinRate">-</strong></div>
                 <div class="profile-stat-card"><span>Streams totales</span><strong id="profileStreams">-</strong></div>
-                <div class="profile-stat-card full"><span>MTOKEN apostados</span><strong id="profileWagered">-</strong></div>
+                <div class="profile-stat-card full"><span>MTR apostados</span><strong id="profileWagered">-</strong></div>
             </div>
 
             <div class="profile-recent-section">
@@ -902,9 +901,9 @@
             const selector = document.getElementById('preferredNetwork');
             if (!selector || typeof PLATFORM_WALLET_ADDRESSES === 'undefined') return;
 
-            const stored = localStorage.getItem('mtr_preferred_network') || 'polygon';
+            const stored = localStorage.getItem('mtr_preferred_network') || 'base';
             const options = Object.keys(PLATFORM_WALLET_ADDRESSES).map((network) => {
-                const label = network.charAt(0).toUpperCase() + network.slice(1);
+                const label = network === 'base' ? 'Base (8453)' : network.charAt(0).toUpperCase() + network.slice(1);
                 const selected = network === stored ? 'selected' : '';
                 return `<option value="${network}" ${selected}>${label}</option>`;
             }).join('');
@@ -916,7 +915,7 @@
         function setPreferredNetwork(network) {
             localStorage.setItem('mtr_preferred_network', network);
             renderWalletDirectory(network);
-            showToast(`Red preferida actualizada: ${network.toUpperCase()}`, 'success');
+            showToast(`Red activa: ${network.toUpperCase()} (chainId 8453)`, 'success');
         }
 
         function submitContactForm(event) {
@@ -940,7 +939,7 @@
             if (!walletDirectory || typeof PLATFORM_WALLET_ADDRESSES === 'undefined') return;
 
             const selector = document.getElementById('preferredNetwork');
-            const activeNetwork = selectedNetwork || selector?.value || localStorage.getItem('mtr_preferred_network') || 'polygon';
+            const activeNetwork = selectedNetwork || selector?.value || localStorage.getItem('mtr_preferred_network') || 'base';
             const selectedAddress = PLATFORM_WALLET_ADDRESSES[activeNetwork];
 
             if (!selectedAddress) {
@@ -1168,19 +1167,11 @@
             }
         }
 
-        function connectWallet() {
-            if (typeof GameEngine !== 'undefined') {
-                GameEngine.connectWallet();
-            } else {
-                showToast('GameEngine no está cargado', 'error');
-            }
-        }
-
         function showIncomingChallenge(challenge) {
             const modal = document.getElementById('challengeModal');
             const details = document.getElementById('challengeDetails');
             if (details) {
-                details.textContent = `${challenge.song.name} - ${challenge.song.artist} | Apuesta: ${challenge.betAmount} $MTOKEN`;
+                details.textContent = `${challenge.song.name} - ${challenge.song.artist} | Apuesta: ${challenge.betAmount} MTR`;
             }
             modal.classList.remove('hidden');
         }
@@ -1202,31 +1193,6 @@
             closeChallengeModal();
             showToast('Reto rechazado', 'info');
         }
-
-        async function verifyDepositTx() {
-            const txHash = document.getElementById('depositTxHash')?.value?.trim();
-            const expectedAmount = parseFloat(document.getElementById('depositAmount')?.value || '0');
-
-            if (!txHash) {
-                showToast('Ingresa el hash de la transacción', 'error');
-                return;
-            }
-
-            if (typeof GameEngine === 'undefined') {
-                showToast('GameEngine no está cargado', 'error');
-                return;
-            }
-
-            const result = await GameEngine.verifyDepositAndCredit(txHash, {
-                network: document.getElementById('preferredNetwork')?.value || 'polygon',
-                expectedAmount: expectedAmount > 0 ? expectedAmount : undefined
-            });
-
-            if (result?.ok) {
-                showToast(`Recarga acreditada: +${result.creditedAmount || result.amount || 0} $MTOKEN`, 'success');
-            }
-        }
-
         async function quoteCashout() {
             const amount = parseFloat(document.getElementById('cashoutAmount')?.value || '0');
             if (!amount || amount <= 0) {
@@ -1241,7 +1207,7 @@
             const quote = await GameEngine.getUsdSettlementQuote(amount);
             const quoteEl = document.getElementById('cashoutQuote');
             if (quoteEl && quote) {
-                quoteEl.textContent = `Referencia: 1 MTOKEN = $${quote.usdRate}. Neto estimado: $${quote.netUsd} (fee ${quote.feePercent}%).`;
+                quoteEl.textContent = `Referencia: 1 MTR = $${quote.usdRate}. Neto estimado: $${quote.netUsd} (fee ${quote.feePercent}%).`;
             }
         }
 
@@ -1257,7 +1223,7 @@
             }
 
             const payout = await GameEngine.requestCashout(amount, {
-                network: document.getElementById('preferredNetwork')?.value || 'polygon'
+                network: 'base'
             });
 
             if (payout?.ok) {
@@ -1265,6 +1231,91 @@
             }
         }
         window.showIncomingChallenge = showIncomingChallenge;
+    </script>
+
+    <script type="module">
+        import { createConfig, http, connect, getAccount, watchAccount, reconnect, readContract } from 'https://esm.sh/@wagmi/core';
+        import { base } from 'https://esm.sh/wagmi/chains';
+        import { injected } from 'https://esm.sh/@wagmi/connectors';
+        import { walletConnect } from 'https://esm.sh/@wagmi/connectors';
+        import { formatUnits } from 'https://esm.sh/viem';
+
+        const MTR_TOKEN = '0x99cd1eb32846c9027ed9cb88710066fa08791c33b';
+        const ERC20_ABI = [
+            { type: 'function', name: 'balanceOf', stateMutability: 'view', inputs: [{ name: 'account', type: 'address' }], outputs: [{ name: '', type: 'uint256' }] }
+        ];
+
+        const wagmiConfig = createConfig({
+            chains: [base],
+            connectors: [
+                injected({ target: 'metaMask' }),
+                walletConnect({ projectId: window.WALLETCONNECT_PROJECT_ID || 'demo-project-id' })
+            ],
+            transports: {
+                [base.id]: http('https://mainnet.base.org')
+            }
+        });
+
+        async function refreshMtrBalance(address) {
+            if (!address) return;
+            try {
+                console.log('[wallet] reading MTR balance', { address });
+                const balance = await readContract(wagmiConfig, {
+                    address: MTR_TOKEN,
+                    abi: ERC20_ABI,
+                    functionName: 'balanceOf',
+                    args: [address]
+                });
+                const formatted = Number(formatUnits(balance, 18)).toLocaleString('es-ES', { maximumFractionDigits: 4 });
+                const badge = document.getElementById('balanceDisplay');
+                const userBalance = document.getElementById('userBalance');
+                if (badge) badge.textContent = `Tu MTR: ${formatted}`;
+                if (userBalance) userBalance.textContent = formatted;
+                console.log('[wallet] MTR balance updated', { formatted });
+            } catch (error) {
+                console.error('[wallet] balance read error', error);
+            }
+        }
+
+        function renderWallet(account) {
+            const walletEl = document.getElementById('walletAddress');
+            const btnEl = document.getElementById('walletConnectBtn');
+            if (!walletEl || !btnEl) return;
+            if (account?.address) {
+                walletEl.textContent = `${account.address.slice(0, 6)}...${account.address.slice(-4)}`;
+                walletEl.classList.remove('hidden');
+                btnEl.textContent = 'Wallet conectada';
+                localStorage.setItem('mtr_wallet', account.address);
+                localStorage.setItem('mtr_wallet_chain', 'base');
+                refreshMtrBalance(account.address);
+            } else {
+                walletEl.classList.add('hidden');
+                btnEl.textContent = 'Conectar Wallet';
+            }
+        }
+
+        async function connectWalletWagmi() {
+            try {
+                console.log('[wallet] connect requested via wagmi');
+                await connect(wagmiConfig, { connector: injected({ target: 'metaMask' }) });
+                renderWallet(getAccount(wagmiConfig));
+            } catch (error) {
+                console.error('[wallet] connect error', error);
+                if (typeof showToast === 'function') showToast('No se pudo conectar la wallet', 'error');
+            }
+        }
+
+        const btn = document.getElementById('walletConnectBtn');
+        if (btn) btn.addEventListener('click', connectWalletWagmi);
+
+        watchAccount(wagmiConfig, {
+            onChange(account) {
+                renderWallet(account);
+            }
+        });
+
+        await reconnect(wagmiConfig);
+        renderWallet(getAccount(wagmiConfig));
     </script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -146,7 +146,7 @@
             <ul>
                 <li>Batallas en las que participas</li>
                 <li>Canciones que seleccionas</li>
-                <li>Apuestas realizadas con $MTOKEN</li>
+                <li>Apuestas realizadas con MTR</li>
                 <li>Historial de victorias y derrotas</li>
                 <li>Estadísticas de juego</li>
             </ul>

--- a/profile.html
+++ b/profile.html
@@ -88,7 +88,7 @@
                 <div class="stat-card">
                     <div class="stat-icon">💰</div>
                     <div class="stat-value" id="totalEarned">0</div>
-                    <div class="stat-label">$MTOKEN Ganados</div>
+                    <div class="stat-label">MTR Ganados</div>
                 </div>
 
                 <div class="stat-card">
@@ -351,7 +351,7 @@
                         
                         <div class="battle-info">
                             <div class="battle-date">${dateStr}</div>
-                            <div class="battle-prize">+${battle.prize_amount} $MTOKEN</div>
+                            <div class="battle-prize">+${battle.prize_amount} MTR</div>
                         </div>
                     </div>
                 `;

--- a/terms.html
+++ b/terms.html
@@ -144,13 +144,13 @@
             <ul>
                 <li>Participar en batallas musicales virtuales</li>
                 <li>Seleccionar canciones para competir</li>
-                <li>Realizar apuestas con $MTOKEN (moneda virtual de la plataforma)</li>
+                <li>Realizar apuestas con MTR (moneda virtual de la plataforma)</li>
                 <li>Competir por premios virtuales</li>
                 <li>Ver estadísticas y rankings</li>
             </ul>
             
             <div class="important">
-                <p><strong>Nota Importante:</strong> $MTOKEN es una moneda virtual de entretenimiento SIN VALOR MONETARIO REAL. No puede ser canjeada por dinero, bienes o servicios fuera de la plataforma.</p>
+                <p><strong>Nota Importante:</strong> MTR es una moneda virtual de entretenimiento SIN VALOR MONETARIO REAL. No puede ser canjeada por dinero, bienes o servicios fuera de la plataforma.</p>
             </div>
         </section>
 
@@ -223,11 +223,11 @@
         </section>
 
         <section>
-            <h2>6. $MTOKEN - Moneda Virtual</h2>
+            <h2>6. MTR - Moneda Virtual</h2>
             
-            <h3>6.1 Naturaleza de $MTOKEN</h3>
+            <h3>6.1 Naturaleza de MTR</h3>
             <div class="important">
-                <p><strong>IMPORTANTE:</strong> $MTOKEN es una moneda virtual de entretenimiento que:</p>
+                <p><strong>IMPORTANTE:</strong> MTR es una moneda virtual de entretenimiento que:</p>
                 <ul>
                     <li>NO tiene valor monetario real</li>
                     <li>NO puede ser canjeada por dinero</li>
@@ -237,8 +237,8 @@
                 </ul>
             </div>
 
-            <h3>6.2 Obtención de $MTOKEN</h3>
-            <p>Puedes obtener $MTOKEN mediante:</p>
+            <h3>6.2 Obtención de MTR</h3>
+            <p>Puedes obtener MTR mediante:</p>
             <ul>
                 <li>Saldo inicial al registrarte</li>
                 <li>Ganar batallas musicales</li>
@@ -247,7 +247,7 @@
             </ul>
 
             <h3>6.3 Sin Reembolsos</h3>
-            <p>$MTOKEN no puede ser reembolsado, canjeado o convertido en valor monetario bajo ninguna circunstancia.</p>
+            <p>MTR no puede ser reembolsado, canjeado o convertido en valor monetario bajo ninguna circunstancia.</p>
         </section>
 
         <section>
@@ -324,7 +324,7 @@
                 <li>Modificar o discontinuar el servicio en cualquier momento</li>
                 <li>Cambiar características o funcionalidades</li>
                 <li>Actualizar estos términos con aviso previo</li>
-                <li>Ajustar el balance de $MTOKEN si detectamos abuso</li>
+                <li>Ajustar el balance de MTR si detectamos abuso</li>
             </ul>
         </section>
 


### PR DESCRIPTION
### Motivation
- Migrar la dApp a la chain Base (chainId 8453) y al token MTR on-chain sin romper la lógica de batallas ni el backend de verificación de apuestas/premios.
- Reemplazar el flujo manual de pegado de hashes por un balance on-chain y un CTA para comprar MTR, y ofrecer pago de premios on-chain desde el backend.

### Description
- Integración de wallet y lectura on-chain: añadí un botón real de conexión que usa Wagmi Core + Viem (connect/reconnect/watchAccount) y lee `balanceOf` del contrato ERC‑20 MTR para mostrar `Tu MTR: X` en la UI (`index.html` + nuevo módulo JS embebido). 
- UX de pagos y textos: eliminé el flujo manual de “pegar hash de tx”, añadí botón `Comprar MTR en Aerodrome` y sección `Sobre MTR`, y reemplacé copys `$MTOKEN/MTOKEN/Polygon` por `MTR/Base` en UI/legal (`index.html`, `auth-system.js`, `profile.html`, `privacy.html`, `terms.html`).
- Configuración blockchain: actualicé `config/config.js` a `CHAIN_ID: 8453`, `RPC_URL: 'https://mainnet.base.org'` y `TOKEN_ADDRESS` al contrato `0x99cd1eb32846c9027ed9cb88710066fa08791c33b`.
- Premios on‑chain (backend): añadí `backend/prize-service.js` con `sendPrize(winner, amount)` implementado con `viem` que llama `transfer()` del ERC‑20 y espera receipt, usando `PRIZE_SIGNER_PRIVATE_KEY` desde variables de entorno (sin hardcodear claves).
- Flujo frontend‑backend de premios: en `game-engine.js` se llama al endpoint `/api/prizes/send` tras actualizar saldo local cuando el usuario gana; se guarda el `txHash` y se muestra enlace a Basescan en la pantalla de victoria; se añadieron logs de depuración para connect/balance/sendPrize.

### Testing
- Ejecuté `npm run check` para verificaciones de integridad del proyecto y éste pasó correctamente. (✅)
- Ejecuté `node --check game-engine.js && node --check auth-system.js && node --check config/config.js && node --check backend/prize-service.js` y todas las comprobaciones de sintaxis JS/Node pasaron correctamente. (✅)
- Intenté generar una captura con Playwright (arranqué servidor estático y abrí `index.html`) pero la navegación devolvió `ERR_EMPTY_RESPONSE` en este entorno, por lo que la captura no pudo completarse; el resto de pruebas automáticas sí fueron exitosas. (❗ fallo de captura automatizada)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f4904700832d8173d4cd93528a1a)