### PR TITLE
feat: migrate wallet + on-chain MTR balance to Base wagmi flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         });
 
         const PLATFORM_WALLET_ADDRESSES = {
-            base: '0x75376BC58830f27415402875D26B73A6BE8E2253'
+            base: '0x99cd1eb32846c9027ed9cb8710066fa08791c33b'
         };
         window.MTR_BUILD_ID = '20260227mtr';
 
@@ -106,12 +106,7 @@
                     <span class="badge" id="balanceDisplay">Tu MTR: --</span>
                 </div>
 
-                <div class="wallet-section">
-                    <button type="button" id="walletConnectBtn" class="btn-secondary btn-wallet">
-                        Conectar Wallet
-                    </button>
-                    <span id="walletAddress" class="wallet-address hidden"></span>
-                </div>
+                <div id="walletApp" class="wallet-section"></div>
                 
                 <!-- AUTH BUTTON -->
                 <div id="authButton">
@@ -265,8 +260,16 @@
                 <div class="settlement-card">
                     <p>Token ERC-20 en Base. Liquidez lockeada en Aerodrome.</p>
                     <p>Contrato: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b.</p>
-                    <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR (<a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">ver en Basescan</a>)</p>
-                    <p>Explorer: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
+                    <div class="basescan-actions">
+                        <a class="btn-basescan" target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">
+                            <span>Ver Contrato</span>
+                            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z"></path><path d="M5 5h6v2H7v10h10v-4h2v6H5V5z"></path></svg>
+                        </a>
+                        <a class="btn-basescan" target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">
+                            <span>Ver Supply 99.99M MTR</span>
+                            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z"></path><path d="M5 5h6v2H7v10h10v-4h2v6H5V5z"></path></svg>
+                        </a>
+                    </div>
                 </div>
             </section>
 
@@ -1235,11 +1238,13 @@
     </script>
 
     <script type="module">
-        import { createConfig, http, connect, getAccount, watchAccount, reconnect, readContract } from 'https://esm.sh/@wagmi/core';
-        import { base } from 'https://esm.sh/wagmi/chains';
-        import { injected } from 'https://esm.sh/@wagmi/connectors';
-        import { walletConnect } from 'https://esm.sh/@wagmi/connectors';
-        import { formatUnits } from 'https://esm.sh/viem';
+        import React, { useEffect } from 'https://esm.sh/react@18.3.1';
+        import { createRoot } from 'https://esm.sh/react-dom@18.3.1/client';
+        import { QueryClient, QueryClientProvider } from 'https://esm.sh/@tanstack/react-query@5.66.9';
+        import { createConfig, http, WagmiProvider, useAccount, useConnect, useReadContract } from 'https://esm.sh/wagmi@2.16.7';
+        import { base } from 'https://esm.sh/wagmi@2.16.7/chains';
+        import { injected } from 'https://esm.sh/wagmi@2.16.7/connectors';
+        import { formatUnits } from 'https://esm.sh/viem@2.23.9';
 
         const MTR_TOKEN = '0x99cd1eb32846c9027ed9cb8710066fa08791c33b';
         const ERC20_ABI = [
@@ -1248,75 +1253,78 @@
 
         const wagmiConfig = createConfig({
             chains: [base],
-            connectors: [
-                injected({ target: 'metaMask' }),
-                walletConnect({ projectId: window.WALLETCONNECT_PROJECT_ID || 'demo-project-id' })
-            ],
+            connectors: [injected({ target: 'metaMask' })],
             transports: {
                 [base.id]: http('https://mainnet.base.org')
             }
         });
 
-        async function refreshMtrBalance(address) {
-            if (!address) return;
-            try {
-                console.log('[wallet] reading MTR balance', { address });
-                const balance = await readContract(wagmiConfig, {
-                    address: MTR_TOKEN,
-                    abi: ERC20_ABI,
-                    functionName: 'balanceOf',
-                    args: [address]
-                });
-                const formatted = Number(formatUnits(balance, 18)).toLocaleString('es-ES', { maximumFractionDigits: 4 });
+        const queryClient = new QueryClient();
+
+        function shortAddress(address) {
+            return `${address.slice(0, 6)}...${address.slice(-4)}`;
+        }
+
+        function WalletPanel() {
+            const { address, isConnected } = useAccount();
+            const { connect, connectors, isPending } = useConnect();
+            const { data: balance } = useReadContract({
+                address: MTR_TOKEN,
+                abi: ERC20_ABI,
+                functionName: 'balanceOf',
+                args: address ? [address] : undefined,
+                query: { enabled: Boolean(address) }
+            });
+
+            const formattedBalance = balance !== undefined
+                ? Number(formatUnits(balance, 18)).toLocaleString('es-ES', { maximumFractionDigits: 4 })
+                : '--';
+
+            useEffect(() => {
                 const badge = document.getElementById('balanceDisplay');
                 const userBalance = document.getElementById('userBalance');
-                if (badge) badge.textContent = `Tu MTR: ${formatted}`;
-                if (userBalance) userBalance.textContent = formatted;
-                console.log('[wallet] MTR balance updated', { formatted });
-            } catch (error) {
-                console.error('[wallet] balance read error', error);
-            }
-        }
+                const value = `${formattedBalance} MTR`;
+                if (badge) badge.textContent = `Tu MTR : ${value}`;
+                if (userBalance) userBalance.textContent = formattedBalance === '--' ? '0' : formattedBalance;
+            }, [formattedBalance]);
 
-        function renderWallet(account) {
-            const walletEl = document.getElementById('walletAddress');
-            const btnEl = document.getElementById('walletConnectBtn');
-            if (!walletEl || !btnEl) return;
-            if (account?.address) {
-                walletEl.textContent = `${account.address.slice(0, 6)}...${account.address.slice(-4)}`;
-                walletEl.classList.remove('hidden');
-                btnEl.textContent = 'Wallet conectada';
-                localStorage.setItem('mtr_wallet', account.address);
+            useEffect(() => {
+                if (!address) return;
+                localStorage.setItem('mtr_wallet', address);
                 localStorage.setItem('mtr_wallet_chain', 'base');
-                refreshMtrBalance(account.address);
-            } else {
-                walletEl.classList.add('hidden');
-                btnEl.textContent = 'Conectar Wallet';
+            }, [address]);
+
+            if (isConnected && address) {
+                return React.createElement(React.Fragment, null,
+                    React.createElement('button', { type: 'button', className: 'btn-secondary btn-wallet', disabled: true }, 'Wallet conectada'),
+                    React.createElement('span', { className: 'wallet-address' }, shortAddress(address))
+                );
             }
+
+            return React.createElement('button', {
+                type: 'button',
+                className: 'btn-secondary btn-wallet',
+                onClick: () => {
+                    const connector = connectors.find((item) => item.id === 'injected') || connectors[0];
+                    if (!connector) return;
+                    connect({ connector });
+                },
+                disabled: isPending
+            }, isPending ? 'Conectando...' : 'Conectar Wallet');
         }
 
-        async function connectWalletWagmi() {
-            try {
-                console.log('[wallet] connect requested via wagmi');
-                await connect(wagmiConfig, { connector: injected({ target: 'metaMask' }) });
-                renderWallet(getAccount(wagmiConfig));
-            } catch (error) {
-                console.error('[wallet] connect error', error);
-                if (typeof showToast === 'function') showToast('No se pudo conectar la wallet', 'error');
-            }
+        function WalletApp() {
+            return React.createElement(WagmiProvider, { config: wagmiConfig },
+                React.createElement(QueryClientProvider, { client: queryClient },
+                    React.createElement(WalletPanel)
+                )
+            );
         }
 
-        const btn = document.getElementById('walletConnectBtn');
-        if (btn) btn.addEventListener('click', connectWalletWagmi);
-
-        watchAccount(wagmiConfig, {
-            onChange(account) {
-                renderWallet(account);
-            }
-        });
-
-        await reconnect(wagmiConfig);
-        renderWallet(getAccount(wagmiConfig));
+        const walletRoot = document.getElementById('walletApp');
+        if (walletRoot) {
+            createRoot(walletRoot).render(React.createElement(WalletApp));
+        }
     </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,5 +7,10 @@
     "build": "echo 'Static site: no build required'",
     "preview": "npx serve .",
     "check": "node --check app.js && node --check top-streams-fallback.js && node --check src/app.js && node --check src/top-streams-fallback.js && node scripts/verify-runtime-integrity.js"
+  },
+  "dependencies": {
+    "wagmi": "^2.16.7",
+    "viem": "^2.23.9",
+    "@tanstack/react-query": "^5.66.9"
   }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -542,6 +542,37 @@ body {
     color: var(--text-secondary);
     font-size: 12px;
 }
+
+.basescan-actions {
+    display: grid;
+    gap: 10px;
+}
+
+.btn-basescan {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    background: #2563eb;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 13px;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.btn-basescan:hover {
+    background: #1d4ed8;
+    transform: translateY(-1px);
+}
+
+.btn-basescan svg {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+}
 .feature-item {
     background: var(--bg-secondary);
     padding: 16px;

--- a/wagmi.config.js
+++ b/wagmi.config.js
@@ -1,0 +1,11 @@
+import { createConfig, http } from 'wagmi'
+import { base } from 'wagmi/chains'
+
+export const wagmiConfig = createConfig({
+  chains: [base],
+  transports: {
+    [base.id]: http('https://mainnet.base.org'),
+  },
+})
+
+export default wagmiConfig


### PR DESCRIPTION
### Motivation
- Make the site read real on-chain MTR balances on Base and replace fragile manual wallet code with a proper wagmi/viem/react-query flow.
- Remove leftover visual cruft from recent updates and provide consistent, user-friendly contract actions for Basescan.
- Unify displayed contract address everywhere to the canonical MTR token to avoid mismatches that caused manual fixes during merges.

### Description
- Declared `wagmi`, `viem` and `@tanstack/react-query` in `package.json` and added `wagmi.config.js` configured for Base mainnet (RPC `https://mainnet.base.org`).
- Replaced the legacy wallet UI with a small React-based `WalletApp` using `useConnect` + `useAccount` and `useReadContract` to fetch `balanceOf` and show the short address when connected, formatting with `formatUnits`.
- Replaced textual contract links with two styled Basescan action buttons (`Ver Contrato` and `Ver Supply 99.99M MTR`) and added corresponding CSS rules for `.btn-basescan` and `.basescan-actions` in `styles/main.css`.
- Replaced all visible addresses and the `PLATFORM_WALLET_ADDRESSES.base` entry with `0x99cd1eb32846c9027ed9cb8710066fa08791c33b` and committed the requested sequence of commits: `feat: wagmi setup`, `feat: on-chain balance`, `fix: botones bonitos`, `fix: checksum final`.

### Testing
- Ran `npm run check` which completed successfully and reported `runtime-integrity-ok`.
- Attempted `npm i wagmi viem @tanstack/react-query` but the install was blocked by the environment registry (HTTP 403), so dependencies are declared but not installed in this environment.
- Started a local preview server with `python -m http.server 4173` which served `http://127.0.0.1:4173/index.html` for manual verification in-session.
- Automated Playwright screenshot attempts timed out in this environment and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19fd733f4832da157e54315b8a53b)