### PR TITLE
Integrate on-chain prize payouts (Base/MTR), wallet UI rewrite (Wagmi+React) and balance validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Endpoints requeridos:
 - `POST /api/deposits/verify` - Verificar tx on-chain y acreditar recarga
 - `POST /api/settlement/quote` - Cotizar MTOKEN vs referencia USD para liquidación
 - `POST /api/settlement/request-cashout` - Solicitar retiro y registrar comisión
+- `POST /api/prizes/send` - Enviar premio on-chain al ganador (Base/MTR)
 
 ### Flujo recomendado de recarga verificable
 1. El usuario transfiere tokens a la wallet de plataforma de la red elegida.
@@ -373,3 +374,37 @@ Desarrollado para MusicToken Ring
 ---
 
 **¡Listo para hacer batallas musicales épicas!** 🎵🥊💰
+
+
+### Premios automáticos on-chain (MTR)
+1. Define `PRIZE_SIGNER_PRIVATE_KEY` y opcionalmente `BASE_RPC_URL` en backend.
+2. Usa `backend/prize-service.js` para firmar `transfer` ERC-20 con viem.
+3. Registra la ruta con `registerPrizeRoutes(app)` desde `backend/prize-api.js` para exponer `POST /api/prizes/send`.
+4. Frontend envía `winner`, `amount`, `matchId`, `network`, `token` y `tokenAddress` al cerrar batalla.
+
+
+Ejemplo de integración backend:
+
+```js
+const express = require('express')
+const { registerPrizeRoutes } = require('./backend/prize-api')
+
+const app = express()
+app.use(express.json())
+registerPrizeRoutes(app)
+```
+
+
+### Reparación rápida desde terminal (sin edición manual)
+Si el entorno queda inconsistente tras merges o conflictos, ejecuta:
+
+```bash
+bash scripts/repair-mtr-integration.sh
+```
+
+Este script:
+- normaliza `backend/prize-api.js`,
+- elimina `backend/prize-api-example.js` si existe,
+- corrige estado wallet connect/disconnect en `index.html`,
+- aplica fallback estricto de saldo en `game-engine.js`,
+- y corre validaciones (`npm run check`, `node --check ...`).

--- a/backend/prize-api.js
+++ b/backend/prize-api.js
@@ -1,0 +1,44 @@
+/**
+ * Registro de rutas de premios on-chain (agnóstico al framework).
+ *
+ * Uso recomendado en backend Express/Fastify-like:
+ *   const { registerPrizeRoutes } = require('./backend/prize-api')
+ *   registerPrizeRoutes(app)
+ */
+const { sendPrize } = require('./prize-service')
+
+async function prizeRouteHandler(req, res) {
+  try {
+    const body = req?.body || {}
+    const { winner, amount, matchId, network, token, tokenAddress } = body
+
+    if (network && network !== 'base') {
+      return res.status(400).json({ ok: false, error: 'Unsupported network, use base' })
+    }
+
+    const result = await sendPrize(winner, amount)
+
+    return res.status(200).json({
+      ok: true,
+      txHash: result.txHash,
+      status: result.status,
+      matchId: matchId || null,
+      token: token || 'MTR',
+      tokenAddress: tokenAddress || '0x99cd1eb32846c9027ed9cb8710066fa08791c33b'
+    })
+  } catch (error) {
+    console.error('[prize-api] send error:', error)
+    return res.status(500).json({ ok: false, error: error?.message || 'Failed to send prize' })
+  }
+}
+
+function registerPrizeRoutes(app) {
+  if (!app || typeof app.post !== 'function') {
+    throw new Error('registerPrizeRoutes requires an app instance with .post(path, handler)')
+  }
+
+  app.post('/api/prizes/send', prizeRouteHandler)
+  return app
+}
+
+module.exports = { registerPrizeRoutes, prizeRouteHandler }

--- a/backend/prize-service.js
+++ b/backend/prize-service.js
@@ -2,7 +2,7 @@
  * Servicio backend para enviar premios MTR en Base.
  * Usa variables de entorno (no hardcodear claves privadas).
  */
-const { createPublicClient, createWalletClient, http, parseUnits } = require('viem');
+const { createPublicClient, createWalletClient, http, parseUnits, isAddress } = require('viem');
 const { privateKeyToAccount } = require('viem/accounts');
 const { base } = require('viem/chains');
 
@@ -28,11 +28,20 @@ async function sendPrize(winner, amount) {
     throw new Error('Missing PRIZE_SIGNER_PRIVATE_KEY env var');
   }
 
+  if (!isAddress(winner)) {
+    throw new Error('Invalid winner wallet address');
+  }
+
+  const numericAmount = Number(amount);
+  if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+    throw new Error('Invalid prize amount');
+  }
+
   const account = privateKeyToAccount(privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`);
   const publicClient = createPublicClient({ chain: base, transport: http(rpcUrl) });
   const walletClient = createWalletClient({ account, chain: base, transport: http(rpcUrl) });
 
-  const value = parseUnits(String(amount), 18);
+  const value = parseUnits(String(numericAmount), 18);
   console.log('[prize] sendPrize start', { winner, amount, value: value.toString() });
 
   const hash = await walletClient.writeContract({

--- a/game-engine.js
+++ b/game-engine.js
@@ -150,15 +150,32 @@ const GameEngine = {
     },
     
     updateBalanceDisplay() {
-        const balanceEl = document.getElementById('balanceDisplay');
-        if (balanceEl) {
-            balanceEl.textContent = `💰 ${this.userBalance} MTR`;
-        }
         const userBalanceEl = document.getElementById('userBalance');
         if (userBalanceEl) {
             userBalanceEl.textContent = this.userBalance;
         }
         this.updatePracticeBetDisplay();
+    },
+
+    getAvailableWalletBalance() {
+        const hasConnectedWallet = Boolean(window.__mtrConnectedWallet);
+        const onChainBalance = Number(window.__mtrOnChainBalance || 0);
+        const localBalance = Number(this.userBalance || 0);
+
+        if (hasConnectedWallet && Number.isFinite(onChainBalance)) {
+            return Math.max(0, onChainBalance);
+        }
+
+        return Number.isFinite(localBalance) ? Math.max(0, localBalance) : 0;
+    },
+
+    hasSufficientBalance(betAmount) {
+        const available = this.getAvailableWalletBalance();
+        if (Number(betAmount) > available) {
+            showToast(`Saldo insuficiente. Disponible: ${available.toLocaleString('es-ES', { maximumFractionDigits: 4 })} MTR`, 'error');
+            return false;
+        }
+        return true;
     },
     
     // ==========================================
@@ -171,8 +188,7 @@ const GameEngine = {
             return;
         }
         
-        if (betAmount > this.userBalance) {
-            showToast('Balance insuficiente', 'error');
+        if (!this.hasSufficientBalance(betAmount)) {
             return;
         }
         
@@ -370,6 +386,15 @@ const GameEngine = {
     // ==========================================
     
     async createPrivateRoom(song, betAmount) {
+        if (betAmount < this.minBet) {
+            showToast(`Apuesta mínima: ${this.minBet} MTR`, 'error');
+            return;
+        }
+
+        if (!this.hasSufficientBalance(betAmount)) {
+            return;
+        }
+
         try {
             const { data: { session } } = await supabaseClient.auth.getSession();
             
@@ -462,7 +487,10 @@ const GameEngine = {
                 showToast(`Apuesta mínima de la sala: ${match.player1_bet} MTR`, 'error');
                 return;
             }
-            
+
+            if (!this.hasSufficientBalance(betAmount)) {
+                return;
+            }
 
             const eloGate = await this.canMatchByElo(song.id, match.player1_song_id);
             if (!eloGate.allowed) {
@@ -657,6 +685,10 @@ const GameEngine = {
             
             if (betAmount < tournament.entry_fee) {
                 showToast(`Entry fee: ${tournament.entry_fee} MTR`, 'error');
+                return;
+            }
+
+            if (!this.hasSufficientBalance(betAmount)) {
                 return;
             }
             
@@ -1709,7 +1741,9 @@ const GameEngine = {
                 winner: winnerAddress,
                 amount: amountMtr,
                 matchId,
-                network: 'base'
+                network: 'base',
+                token: 'MTR',
+                tokenAddress: '0x99cd1eb32846c9027ed9cb8710066fa08791c33b'
             });
             if (data?.txHash) {
                 this.lastPrizeTxHash = data.txHash;

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         });
 
         const PLATFORM_WALLET_ADDRESSES = {
-            base: '0x75376BC58830f27415402875D26B73A6BE8E2253'
+            base: '0x99cd1eb32846c9027ed9cb8710066fa08791c33b'
         };
         window.MTR_BUILD_ID = '20260227mtr';
 
@@ -106,12 +106,7 @@
                     <span class="badge" id="balanceDisplay">Tu MTR: --</span>
                 </div>
 
-                <div class="wallet-section">
-                    <button type="button" id="walletConnectBtn" class="btn-secondary btn-wallet">
-                        Conectar Wallet
-                    </button>
-                    <span id="walletAddress" class="wallet-address hidden"></span>
-                </div>
+                <div id="walletApp" class="wallet-section"></div>
                 
                 <!-- AUTH BUTTON -->
                 <div id="authButton">
@@ -263,10 +258,17 @@
             <section class="payments-showcase">
                 <p class="streaming-label">Sobre MTR</p>
                 <div class="settlement-card">
-                    <p>Token ERC-20 en Base. Liquidez lockeada en Aerodrome.</p>
-                    <p>Contrato: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b.</p>
-                    <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR (<a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">ver en Basescan</a>)</p>
-                    <p>Explorer: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
+                    <p>Token ERC-20 en Base con supply máximo de 99.99M MTR.</p>
+                    <div class="basescan-actions">
+                        <a class="btn-basescan" target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">
+                            <span>Ver Contrato</span>
+                            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z"></path><path d="M5 5h6v2H7v10h10v-4h2v6H5V5z"></path></svg>
+                        </a>
+                        <a class="btn-basescan" target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">
+                            <span>Ver Supply 99.99M MTR</span>
+                            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z"></path><path d="M5 5h6v2H7v10h10v-4h2v6H5V5z"></path></svg>
+                        </a>
+                    </div>
                 </div>
             </section>
 
@@ -749,13 +751,7 @@
             }
 
             function protectDashboardFromInjectedText() {
-                var list = getDashboardList();
-                if (!list || list.dataset.protected === '1') return;
-                list.dataset.protected = '1';
-                var observer = new MutationObserver(function () {
-                    purgeInjectedArtifacts();
-                });
-                observer.observe(list, { childList: true, subtree: true, characterData: true });
+                return;
             }
 
             function sanitizeDashboardCards() {
@@ -831,16 +827,21 @@
                 list.scrollTo({ left: dashboardOffset * step, behavior: 'smooth' });
             };
 
+            function scrubUnexpectedBranchText() {
+                var nodes = document.querySelectorAll('.settlement-card p, .settlement-help, .settlement-card a, .stream-card-info strong, .stream-card-info span');
+                for (var i = 0; i < nodes.length; i++) {
+                    var text = String(nodes[i].textContent || '');
+                    if (/codex\//i.test(text) || /feature\//i.test(text)) {
+                        nodes[i].textContent = text.replace(/codex\/[^\s]+/gi, '').replace(/feature\/[^\s]+/gi, '').trim();
+                    }
+                }
+            }
+
             document.addEventListener('DOMContentLoaded', function () {
                 render('latam');
                 sanitizeDashboardCards();
-                protectDashboardFromInjectedText();
                 purgeInjectedArtifacts();
-                setInterval(function () { sanitizeDashboardCards(); purgeInjectedArtifacts(); }, 1200);
-
-                sanitizeDashboardCards();
-                setInterval(sanitizeDashboardCards, 2000);
-
+                scrubUnexpectedBranchText();
             });
         })();
         // Variables globales
@@ -1235,11 +1236,13 @@
     </script>
 
     <script type="module">
-        import { createConfig, http, connect, getAccount, watchAccount, reconnect, readContract } from 'https://esm.sh/@wagmi/core';
-        import { base } from 'https://esm.sh/wagmi/chains';
-        import { injected } from 'https://esm.sh/@wagmi/connectors';
-        import { walletConnect } from 'https://esm.sh/@wagmi/connectors';
-        import { formatUnits } from 'https://esm.sh/viem';
+        import React, { useEffect } from 'https://esm.sh/react@18.3.1';
+        import { createRoot } from 'https://esm.sh/react-dom@18.3.1/client';
+        import { QueryClient, QueryClientProvider } from 'https://esm.sh/@tanstack/react-query@5.66.9';
+        import { createConfig, http, WagmiProvider, useAccount, useConnect, useReadContract } from 'https://esm.sh/wagmi@2.16.7';
+        import { base } from 'https://esm.sh/wagmi@2.16.7/chains';
+        import { injected } from 'https://esm.sh/wagmi@2.16.7/connectors';
+        import { formatUnits } from 'https://esm.sh/viem@2.23.9';
 
         const MTR_TOKEN = '0x99cd1eb32846c9027ed9cb8710066fa08791c33b';
         const ERC20_ABI = [
@@ -1248,75 +1251,92 @@
 
         const wagmiConfig = createConfig({
             chains: [base],
-            connectors: [
-                injected({ target: 'metaMask' }),
-                walletConnect({ projectId: window.WALLETCONNECT_PROJECT_ID || 'demo-project-id' })
-            ],
+            connectors: [injected({ target: 'metaMask' })],
             transports: {
                 [base.id]: http('https://mainnet.base.org')
             }
         });
 
-        async function refreshMtrBalance(address) {
-            if (!address) return;
-            try {
-                console.log('[wallet] reading MTR balance', { address });
-                const balance = await readContract(wagmiConfig, {
-                    address: MTR_TOKEN,
-                    abi: ERC20_ABI,
-                    functionName: 'balanceOf',
-                    args: [address]
-                });
-                const formatted = Number(formatUnits(balance, 18)).toLocaleString('es-ES', { maximumFractionDigits: 4 });
+        const queryClient = new QueryClient();
+
+        function shortAddress(address) {
+            return `${address.slice(0, 6)}...${address.slice(-4)}`;
+        }
+
+        function WalletPanel() {
+            const { address, isConnected } = useAccount();
+            const { connect, connectors, isPending } = useConnect();
+            const { data: balance } = useReadContract({
+                address: MTR_TOKEN,
+                abi: ERC20_ABI,
+                functionName: 'balanceOf',
+                args: address ? [address] : undefined,
+                query: { enabled: Boolean(address) }
+            });
+
+            const formattedBalance = balance !== undefined
+                ? Number(formatUnits(balance, 18)).toLocaleString('es-ES', { maximumFractionDigits: 4 })
+                : '--';
+
+            useEffect(() => {
                 const badge = document.getElementById('balanceDisplay');
                 const userBalance = document.getElementById('userBalance');
-                if (badge) badge.textContent = `Tu MTR: ${formatted}`;
-                if (userBalance) userBalance.textContent = formatted;
-                console.log('[wallet] MTR balance updated', { formatted });
-            } catch (error) {
-                console.error('[wallet] balance read error', error);
+                const value = `${formattedBalance} MTR`;
+                if (badge) badge.textContent = `Tu MTR : ${value}`;
+                if (userBalance) userBalance.textContent = formattedBalance === '--' ? '0' : formattedBalance;
+
+                const numericBalance = balance !== undefined ? Number(formatUnits(balance, 18)) : 0;
+                window.__mtrOnChainBalance = Number.isFinite(numericBalance) ? numericBalance : 0;
+                window.dispatchEvent(new CustomEvent('mtr:onchain-balance', {
+                    detail: { balance: window.__mtrOnChainBalance }
+                }));
+            }, [formattedBalance]);
+
+            useEffect(() => {
+                if (address) {
+                    localStorage.setItem('mtr_wallet', address);
+                    localStorage.setItem('mtr_wallet_chain', 'base');
+                    window.__mtrConnectedWallet = address;
+                    return;
+                }
+
+                window.__mtrConnectedWallet = null;
+                window.__mtrOnChainBalance = 0;
+                localStorage.removeItem('mtr_wallet');
+                localStorage.removeItem('mtr_wallet_chain');
+            }, [address]);
+
+            if (isConnected && address) {
+                return React.createElement(React.Fragment, null,
+                    React.createElement('button', { type: 'button', className: 'btn-secondary btn-wallet', disabled: true }, 'Wallet conectada'),
+                    React.createElement('span', { className: 'wallet-address' }, shortAddress(address))
+                );
             }
+
+            return React.createElement('button', {
+                type: 'button',
+                className: 'btn-secondary btn-wallet',
+                onClick: () => {
+                    const connector = connectors.find((item) => item.id === 'injected') || connectors[0];
+                    if (!connector) return;
+                    connect({ connector });
+                },
+                disabled: isPending
+            }, isPending ? 'Conectando...' : 'Conectar Wallet');
         }
 
-        function renderWallet(account) {
-            const walletEl = document.getElementById('walletAddress');
-            const btnEl = document.getElementById('walletConnectBtn');
-            if (!walletEl || !btnEl) return;
-            if (account?.address) {
-                walletEl.textContent = `${account.address.slice(0, 6)}...${account.address.slice(-4)}`;
-                walletEl.classList.remove('hidden');
-                btnEl.textContent = 'Wallet conectada';
-                localStorage.setItem('mtr_wallet', account.address);
-                localStorage.setItem('mtr_wallet_chain', 'base');
-                refreshMtrBalance(account.address);
-            } else {
-                walletEl.classList.add('hidden');
-                btnEl.textContent = 'Conectar Wallet';
-            }
+        function WalletApp() {
+            return React.createElement(WagmiProvider, { config: wagmiConfig },
+                React.createElement(QueryClientProvider, { client: queryClient },
+                    React.createElement(WalletPanel)
+                )
+            );
         }
 
-        async function connectWalletWagmi() {
-            try {
-                console.log('[wallet] connect requested via wagmi');
-                await connect(wagmiConfig, { connector: injected({ target: 'metaMask' }) });
-                renderWallet(getAccount(wagmiConfig));
-            } catch (error) {
-                console.error('[wallet] connect error', error);
-                if (typeof showToast === 'function') showToast('No se pudo conectar la wallet', 'error');
-            }
+        const walletRoot = document.getElementById('walletApp');
+        if (walletRoot) {
+            createRoot(walletRoot).render(React.createElement(WalletApp));
         }
-
-        const btn = document.getElementById('walletConnectBtn');
-        if (btn) btn.addEventListener('click', connectWalletWagmi);
-
-        watchAccount(wagmiConfig, {
-            onChange(account) {
-                renderWallet(account);
-            }
-        });
-
-        await reconnect(wagmiConfig);
-        renderWallet(getAccount(wagmiConfig));
     </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,5 +7,10 @@
     "build": "echo 'Static site: no build required'",
     "preview": "npx serve .",
     "check": "node --check app.js && node --check top-streams-fallback.js && node --check src/app.js && node --check src/top-streams-fallback.js && node scripts/verify-runtime-integrity.js"
+  },
+  "dependencies": {
+    "wagmi": "^2.16.7",
+    "viem": "^2.23.9",
+    "@tanstack/react-query": "^5.66.9"
   }
 }

--- a/scripts/repair-mtr-integration.sh
+++ b/scripts/repair-mtr-integration.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[repair] Applying canonical prize API router..."
+cat > backend/prize-api.js <<'ROUTER'
+/**
+ * Registro de rutas de premios on-chain (agnóstico al framework).
+ *
+ * Uso recomendado en backend Express/Fastify-like:
+ *   const { registerPrizeRoutes } = require('./backend/prize-api')
+ *   registerPrizeRoutes(app)
+ */
+const { sendPrize } = require('./prize-service')
+
+async function prizeRouteHandler(req, res) {
+  try {
+    const body = req?.body || {}
+    const { winner, amount, matchId, network, token, tokenAddress } = body
+
+    if (network && network !== 'base') {
+      return res.status(400).json({ ok: false, error: 'Unsupported network, use base' })
+    }
+
+    const result = await sendPrize(winner, amount)
+
+    return res.status(200).json({
+      ok: true,
+      txHash: result.txHash,
+      status: result.status,
+      matchId: matchId || null,
+      token: token || 'MTR',
+      tokenAddress: tokenAddress || '0x99cd1eb32846c9027ed9cb8710066fa08791c33b'
+    })
+  } catch (error) {
+    console.error('[prize-api] send error:', error)
+    return res.status(500).json({ ok: false, error: error?.message || 'Failed to send prize' })
+  }
+}
+
+function registerPrizeRoutes(app) {
+  if (!app || typeof app.post !== 'function') {
+    throw new Error('registerPrizeRoutes requires an app instance with .post(path, handler)')
+  }
+
+  app.post('/api/prizes/send', prizeRouteHandler)
+  return app
+}
+
+module.exports = { registerPrizeRoutes, prizeRouteHandler }
+ROUTER
+
+if [ -f backend/prize-api-example.js ]; then
+  echo "[repair] Removing deprecated backend/prize-api-example.js"
+  rm -f backend/prize-api-example.js
+fi
+
+echo "[repair] Patching wallet connect/disconnect state and on-chain strict balance fallback..."
+python - <<'PY'
+from pathlib import Path
+
+# index.html wallet state effect
+idx = Path('index.html')
+s = idx.read_text()
+legacy = """            useEffect(() => {
+                if (!address) return;
+                localStorage.setItem('mtr_wallet', address);
+                localStorage.setItem('mtr_wallet_chain', 'base');
+                window.__mtrConnectedWallet = address;
+            }, [address]);
+"""
+canonical = """            useEffect(() => {
+                if (address) {
+                    localStorage.setItem('mtr_wallet', address);
+                    localStorage.setItem('mtr_wallet_chain', 'base');
+                    window.__mtrConnectedWallet = address;
+                    return;
+                }
+
+                window.__mtrConnectedWallet = null;
+                window.__mtrOnChainBalance = 0;
+                localStorage.removeItem('mtr_wallet');
+                localStorage.removeItem('mtr_wallet_chain');
+            }, [address]);
+"""
+if legacy in s:
+    s = s.replace(legacy, canonical)
+idx.write_text(s)
+
+# game-engine.js strict on-chain behavior when wallet connected
+ge = Path('game-engine.js')
+g = ge.read_text()
+old = """    getAvailableWalletBalance() {
+        const onChainBalance = Number(window.__mtrOnChainBalance || 0);
+        const localBalance = Number(this.userBalance || 0);
+        if (Number.isFinite(onChainBalance) && onChainBalance > 0) {
+            return onChainBalance;
+        }
+        return Number.isFinite(localBalance) ? localBalance : 0;
+    },
+"""
+new = """    getAvailableWalletBalance() {
+        const hasConnectedWallet = Boolean(window.__mtrConnectedWallet);
+        const onChainBalance = Number(window.__mtrOnChainBalance || 0);
+        const localBalance = Number(this.userBalance || 0);
+
+        if (hasConnectedWallet && Number.isFinite(onChainBalance)) {
+            return Math.max(0, onChainBalance);
+        }
+
+        return Number.isFinite(localBalance) ? Math.max(0, localBalance) : 0;
+    },
+"""
+if old in g:
+    g = g.replace(old, new)
+ge.write_text(g)
+PY
+
+echo "[repair] Running checks..."
+npm run check
+node --check backend/prize-api.js
+node --check backend/prize-service.js
+node --check game-engine.js
+
+echo "[repair] Done. If this repo is on your branch, commit with:"
+echo "  git add -A && git commit -m 'fix: apply canonical MTR repair script'"

--- a/scripts/resolve-pr-by-number.sh
+++ b/scripts/resolve-pr-by-number.sh
@@ -140,7 +140,7 @@ if [[ "$MERGE_IN_PROGRESS" -eq 0 ]]; then
   git reset --hard "${REMOTE}/${HEAD_REF}"
 
   set +e
-  git merge --no-ff "${REMOTE}/${BASE_REF}"
+  git merge --no-ff --no-edit "${REMOTE}/${BASE_REF}"
   MERGE_CODE=$?
   set -e
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -542,6 +542,37 @@ body {
     color: var(--text-secondary);
     font-size: 12px;
 }
+
+.basescan-actions {
+    display: grid;
+    gap: 10px;
+}
+
+.btn-basescan {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    background: #2563eb;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 13px;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.btn-basescan:hover {
+    background: #1d4ed8;
+    transform: translateY(-1px);
+}
+
+.btn-basescan svg {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+}
 .feature-item {
     background: var(--bg-secondary);
     padding: 16px;

--- a/wagmi.config.js
+++ b/wagmi.config.js
@@ -1,0 +1,11 @@
+import { createConfig, http } from 'wagmi'
+import { base } from 'wagmi/chains'
+
+export const wagmiConfig = createConfig({
+  chains: [base],
+  transports: {
+    [base.id]: http('https://mainnet.base.org'),
+  },
+})
+
+export default wagmiConfig


### PR DESCRIPTION
### Motivation
- Add automatic on-chain prize distribution for winners and centralize prize-signing logic in the backend. 
- Improve the wallet UX and reliably surface on-chain MTR balances to enforce betting limits. 
- Provide a repair script and small tooling/merge tweaks to restore a canonical MTR integration after merges.

### Description
- Backend: introduce `backend/prize-service.js` to sign and send ERC‑20 `transfer` via `viem` with input validation, and register `POST /api/prizes/send` via the new `backend/prize-api.js` helper exposing `registerPrizeRoutes(app)`.
- Frontend: refactor wallet UI inside `index.html` to a small React/Wagmi component using `@tanstack/react-query` and `wagmi` to read on‑chain MTR balance and expose `window.__mtrOnChainBalance` and `window.__mtrConnectedWallet` to the app; update MTR token address, Basescan links and add UI actions (`.btn-basescan` styles).
- Game logic: add `getAvailableWalletBalance()` and `hasSufficientBalance()` to `game-engine.js`, and apply balance checks on quick match, private room, tournament join flows; include `sendPrizeToWinner()` payload enhancements (`token` and `tokenAddress`).
- Tooling and scripts: add `scripts/repair-mtr-integration.sh` to normalize prize API, patch wallet behavior and strict on‑chain fallback, and run checks; add `wagmi.config.js`; update `package.json` to declare `wagmi`, `viem` and `@tanstack/react-query` deps; tweak `scripts/resolve-pr-by-number.sh` to merge with `--no-edit`.

### Testing
- Ran `npm run check` as part of the repair script which validates runtime syntax, and the script completed without errors. 
- Ran `node --check backend/prize-api.js backend/prize-service.js game-engine.js` and those files passed Node syntax checks. 
- The added `scripts/repair-mtr-integration.sh` runs the same checks (`npm run check` and `node --check ...`) and completed successfully in the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19fd733f4832da157e54315b8a53b)