### PR TITLE
Add on-chain prize payout API and MTR integration (backend, frontend, scripts, deps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Endpoints requeridos:
 - `POST /api/deposits/verify` - Verificar tx on-chain y acreditar recarga
 - `POST /api/settlement/quote` - Cotizar MTOKEN vs referencia USD para liquidación
 - `POST /api/settlement/request-cashout` - Solicitar retiro y registrar comisión
+- `POST /api/prizes/send` - Enviar premio on-chain al ganador (Base/MTR)
 
 ### Flujo recomendado de recarga verificable
 1. El usuario transfiere tokens a la wallet de plataforma de la red elegida.
@@ -373,3 +374,37 @@ Desarrollado para MusicToken Ring
 ---
 
 **¡Listo para hacer batallas musicales épicas!** 🎵🥊💰
+
+
+### Premios automáticos on-chain (MTR)
+1. Define `PRIZE_SIGNER_PRIVATE_KEY` y opcionalmente `BASE_RPC_URL` en backend.
+2. Usa `backend/prize-service.js` para firmar `transfer` ERC-20 con viem.
+3. Registra la ruta con `registerPrizeRoutes(app)` desde `backend/prize-api.js` para exponer `POST /api/prizes/send`.
+4. Frontend envía `winner`, `amount`, `matchId`, `network`, `token` y `tokenAddress` al cerrar batalla.
+
+
+Ejemplo de integración backend:
+
+```js
+const express = require('express')
+const { registerPrizeRoutes } = require('./backend/prize-api')
+
+const app = express()
+app.use(express.json())
+registerPrizeRoutes(app)
+```
+
+
+### Reparación rápida desde terminal (sin edición manual)
+Si el entorno queda inconsistente tras merges o conflictos, ejecuta:
+
+```bash
+bash scripts/repair-mtr-integration.sh
+```
+
+Este script:
+- normaliza `backend/prize-api.js`,
+- elimina `backend/prize-api-example.js` si existe,
+- corrige estado wallet connect/disconnect en `index.html`,
+- aplica fallback estricto de saldo en `game-engine.js`,
+- y corre validaciones (`npm run check`, `node --check ...`).

--- a/backend/prize-api.js
+++ b/backend/prize-api.js
@@ -1,0 +1,44 @@
+/**
+ * Registro de rutas de premios on-chain (agnóstico al framework).
+ *
+ * Uso recomendado en backend Express/Fastify-like:
+ *   const { registerPrizeRoutes } = require('./backend/prize-api')
+ *   registerPrizeRoutes(app)
+ */
+const { sendPrize } = require('./prize-service')
+
+async function prizeRouteHandler(req, res) {
+  try {
+    const body = req?.body || {}
+    const { winner, amount, matchId, network, token, tokenAddress } = body
+
+    if (network && network !== 'base') {
+      return res.status(400).json({ ok: false, error: 'Unsupported network, use base' })
+    }
+
+    const result = await sendPrize(winner, amount)
+
+    return res.status(200).json({
+      ok: true,
+      txHash: result.txHash,
+      status: result.status,
+      matchId: matchId || null,
+      token: token || 'MTR',
+      tokenAddress: tokenAddress || '0x99cd1eb32846c9027ed9cb8710066fa08791c33b'
+    })
+  } catch (error) {
+    console.error('[prize-api] send error:', error)
+    return res.status(500).json({ ok: false, error: error?.message || 'Failed to send prize' })
+  }
+}
+
+function registerPrizeRoutes(app) {
+  if (!app || typeof app.post !== 'function') {
+    throw new Error('registerPrizeRoutes requires an app instance with .post(path, handler)')
+  }
+
+  app.post('/api/prizes/send', prizeRouteHandler)
+  return app
+}
+
+module.exports = { registerPrizeRoutes, prizeRouteHandler }

--- a/backend/prize-service.js
+++ b/backend/prize-service.js
@@ -2,7 +2,7 @@
  * Servicio backend para enviar premios MTR en Base.
  * Usa variables de entorno (no hardcodear claves privadas).
  */
-const { createPublicClient, createWalletClient, http, parseUnits } = require('viem');
+const { createPublicClient, createWalletClient, http, parseUnits, isAddress } = require('viem');
 const { privateKeyToAccount } = require('viem/accounts');
 const { base } = require('viem/chains');
 
@@ -28,11 +28,20 @@ async function sendPrize(winner, amount) {
     throw new Error('Missing PRIZE_SIGNER_PRIVATE_KEY env var');
   }
 
+  if (!isAddress(winner)) {
+    throw new Error('Invalid winner wallet address');
+  }
+
+  const numericAmount = Number(amount);
+  if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+    throw new Error('Invalid prize amount');
+  }
+
   const account = privateKeyToAccount(privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`);
   const publicClient = createPublicClient({ chain: base, transport: http(rpcUrl) });
   const walletClient = createWalletClient({ account, chain: base, transport: http(rpcUrl) });
 
-  const value = parseUnits(String(amount), 18);
+  const value = parseUnits(String(numericAmount), 18);
   console.log('[prize] sendPrize start', { winner, amount, value: value.toString() });
 
   const hash = await walletClient.writeContract({

--- a/game-engine.js
+++ b/game-engine.js
@@ -150,15 +150,32 @@ const GameEngine = {
     },
     
     updateBalanceDisplay() {
-        const balanceEl = document.getElementById('balanceDisplay');
-        if (balanceEl) {
-            balanceEl.textContent = `💰 ${this.userBalance} MTR`;
-        }
         const userBalanceEl = document.getElementById('userBalance');
         if (userBalanceEl) {
             userBalanceEl.textContent = this.userBalance;
         }
         this.updatePracticeBetDisplay();
+    },
+
+    getAvailableWalletBalance() {
+        const hasConnectedWallet = Boolean(window.__mtrConnectedWallet);
+        const onChainBalance = Number(window.__mtrOnChainBalance || 0);
+        const localBalance = Number(this.userBalance || 0);
+
+        if (hasConnectedWallet && Number.isFinite(onChainBalance)) {
+            return Math.max(0, onChainBalance);
+        }
+
+        return Number.isFinite(localBalance) ? Math.max(0, localBalance) : 0;
+    },
+
+    hasSufficientBalance(betAmount) {
+        const available = this.getAvailableWalletBalance();
+        if (Number(betAmount) > available) {
+            showToast(`Saldo insuficiente. Disponible: ${available.toLocaleString('es-ES', { maximumFractionDigits: 4 })} MTR`, 'error');
+            return false;
+        }
+        return true;
     },
     
     // ==========================================
@@ -171,8 +188,7 @@ const GameEngine = {
             return;
         }
         
-        if (betAmount > this.userBalance) {
-            showToast('Balance insuficiente', 'error');
+        if (!this.hasSufficientBalance(betAmount)) {
             return;
         }
         
@@ -370,6 +386,15 @@ const GameEngine = {
     // ==========================================
     
     async createPrivateRoom(song, betAmount) {
+        if (betAmount < this.minBet) {
+            showToast(`Apuesta mínima: ${this.minBet} MTR`, 'error');
+            return;
+        }
+
+        if (!this.hasSufficientBalance(betAmount)) {
+            return;
+        }
+
         try {
             const { data: { session } } = await supabaseClient.auth.getSession();
             
@@ -462,7 +487,10 @@ const GameEngine = {
                 showToast(`Apuesta mínima de la sala: ${match.player1_bet} MTR`, 'error');
                 return;
             }
-            
+
+            if (!this.hasSufficientBalance(betAmount)) {
+                return;
+            }
 
             const eloGate = await this.canMatchByElo(song.id, match.player1_song_id);
             if (!eloGate.allowed) {
@@ -657,6 +685,10 @@ const GameEngine = {
             
             if (betAmount < tournament.entry_fee) {
                 showToast(`Entry fee: ${tournament.entry_fee} MTR`, 'error');
+                return;
+            }
+
+            if (!this.hasSufficientBalance(betAmount)) {
                 return;
             }
             
@@ -1709,7 +1741,9 @@ const GameEngine = {
                 winner: winnerAddress,
                 amount: amountMtr,
                 matchId,
-                network: 'base'
+                network: 'base',
+                token: 'MTR',
+                tokenAddress: '0x99cd1eb32846c9027ed9cb8710066fa08791c33b'
             });
             if (data?.txHash) {
                 this.lastPrizeTxHash = data.txHash;

--- a/package.json
+++ b/package.json
@@ -7,5 +7,10 @@
     "build": "echo 'Static site: no build required'",
     "preview": "npx serve .",
     "check": "node --check app.js && node --check top-streams-fallback.js && node --check src/app.js && node --check src/top-streams-fallback.js && node scripts/verify-runtime-integrity.js"
+  },
+  "dependencies": {
+    "wagmi": "^2.16.7",
+    "viem": "^2.23.9",
+    "@tanstack/react-query": "^5.66.9"
   }
 }

--- a/scripts/repair-mtr-integration.sh
+++ b/scripts/repair-mtr-integration.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[repair] Applying canonical prize API router..."
+cat > backend/prize-api.js <<'ROUTER'
+/**
+ * Registro de rutas de premios on-chain (agnóstico al framework).
+ *
+ * Uso recomendado en backend Express/Fastify-like:
+ *   const { registerPrizeRoutes } = require('./backend/prize-api')
+ *   registerPrizeRoutes(app)
+ */
+const { sendPrize } = require('./prize-service')
+
+async function prizeRouteHandler(req, res) {
+  try {
+    const body = req?.body || {}
+    const { winner, amount, matchId, network, token, tokenAddress } = body
+
+    if (network && network !== 'base') {
+      return res.status(400).json({ ok: false, error: 'Unsupported network, use base' })
+    }
+
+    const result = await sendPrize(winner, amount)
+
+    return res.status(200).json({
+      ok: true,
+      txHash: result.txHash,
+      status: result.status,
+      matchId: matchId || null,
+      token: token || 'MTR',
+      tokenAddress: tokenAddress || '0x99cd1eb32846c9027ed9cb8710066fa08791c33b'
+    })
+  } catch (error) {
+    console.error('[prize-api] send error:', error)
+    return res.status(500).json({ ok: false, error: error?.message || 'Failed to send prize' })
+  }
+}
+
+function registerPrizeRoutes(app) {
+  if (!app || typeof app.post !== 'function') {
+    throw new Error('registerPrizeRoutes requires an app instance with .post(path, handler)')
+  }
+
+  app.post('/api/prizes/send', prizeRouteHandler)
+  return app
+}
+
+module.exports = { registerPrizeRoutes, prizeRouteHandler }
+ROUTER
+
+if [ -f backend/prize-api-example.js ]; then
+  echo "[repair] Removing deprecated backend/prize-api-example.js"
+  rm -f backend/prize-api-example.js
+fi
+
+echo "[repair] Patching wallet connect/disconnect state and on-chain strict balance fallback..."
+python - <<'PY'
+from pathlib import Path
+
+# index.html wallet state effect
+idx = Path('index.html')
+s = idx.read_text()
+legacy = """            useEffect(() => {
+                if (!address) return;
+                localStorage.setItem('mtr_wallet', address);
+                localStorage.setItem('mtr_wallet_chain', 'base');
+                window.__mtrConnectedWallet = address;
+            }, [address]);
+"""
+canonical = """            useEffect(() => {
+                if (address) {
+                    localStorage.setItem('mtr_wallet', address);
+                    localStorage.setItem('mtr_wallet_chain', 'base');
+                    window.__mtrConnectedWallet = address;
+                    return;
+                }
+
+                window.__mtrConnectedWallet = null;
+                window.__mtrOnChainBalance = 0;
+                localStorage.removeItem('mtr_wallet');
+                localStorage.removeItem('mtr_wallet_chain');
+            }, [address]);
+"""
+if legacy in s:
+    s = s.replace(legacy, canonical)
+idx.write_text(s)
+
+# game-engine.js strict on-chain behavior when wallet connected
+ge = Path('game-engine.js')
+g = ge.read_text()
+old = """    getAvailableWalletBalance() {
+        const onChainBalance = Number(window.__mtrOnChainBalance || 0);
+        const localBalance = Number(this.userBalance || 0);
+        if (Number.isFinite(onChainBalance) && onChainBalance > 0) {
+            return onChainBalance;
+        }
+        return Number.isFinite(localBalance) ? localBalance : 0;
+    },
+"""
+new = """    getAvailableWalletBalance() {
+        const hasConnectedWallet = Boolean(window.__mtrConnectedWallet);
+        const onChainBalance = Number(window.__mtrOnChainBalance || 0);
+        const localBalance = Number(this.userBalance || 0);
+
+        if (hasConnectedWallet && Number.isFinite(onChainBalance)) {
+            return Math.max(0, onChainBalance);
+        }
+
+        return Number.isFinite(localBalance) ? Math.max(0, localBalance) : 0;
+    },
+"""
+if old in g:
+    g = g.replace(old, new)
+ge.write_text(g)
+PY
+
+echo "[repair] Running checks..."
+npm run check
+node --check backend/prize-api.js
+node --check backend/prize-service.js
+node --check game-engine.js
+
+echo "[repair] Done. If this repo is on your branch, commit with:"
+echo "  git add -A && git commit -m 'fix: apply canonical MTR repair script'"

--- a/wagmi.config.js
+++ b/wagmi.config.js
@@ -1,0 +1,11 @@
+import { createConfig, http } from 'wagmi'
+import { base } from 'wagmi/chains'
+
+export const wagmiConfig = createConfig({
+  chains: [base],
+  transports: {
+    [base.id]: http('https://mainnet.base.org'),
+  },
+})
+
+export default wagmiConfig


### PR DESCRIPTION
### Motivation

- Enable automatic on-chain prize distribution in MTR (Base) and document integration for backend/frontend. 
- Harden prize sending with input validation and a small repair/consistency tool to recover from merge conflicts. 
- Prefer on-chain wallet balance when connected and ensure frontend checks funds before creating/joining matches/tournaments.

### Description

- Adds a new Express-compatible prize router `backend/prize-api.js` exposing `POST /api/prizes/send` that delegates to `sendPrize` and returns tx info. 
- Implements `backend/prize-service.js` to sign and send ERC-20 `transfer` via `viem`, with RPC/url/env handling, address/amount validation, and transaction receipt awaiting. 
- Updates `game-engine.js` to prefer on-chain balance when a connected wallet is present, add `getAvailableWalletBalance()` and `hasSufficientBalance()`, and apply balance checks before `joinQuickMatch`, `createPrivateRoom`, `joinPrivateRoom`, `joinTournament`; also send token metadata when calling the prize API. 
- Updates `README.md` with prize integration docs, usage example and a quick repair command. 
- Adds repair helper `scripts/repair-mtr-integration.sh` that can regenerate the prize router, patch frontend wallet connect/disconnect behavior, patch `game-engine.js` fallback, and run sanity checks. 
- Enhances `scripts/resolve-pr-by-number.sh` to support `--remote-url`, `--offline-current-merge` and other merge resolution improvements. 
- Adds runtime dependencies to `package.json` (`viem`, `wagmi`, `@tanstack/react-query`) and introduces `wagmi.config.js` with Base chain config.

### Testing

- Ran project checks via `npm run check` and `node --check backend/prize-api.js backend/prize-service.js game-engine.js` and they completed successfully. 
- Executed the included repair script `scripts/repair-mtr-integration.sh` which runs the same checks as part of its flow and returned without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19fd733f4832da157e54315b8a53b)