### PR TITLE
Add Codex patch-conflict recovery script and restore dashboard guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ Esta sección es una guía rápida para cualquier usuario que quiera usar la app
 - ✅ Navega dashboard (tabs + carrusel).
 - ✅ Genera cotización y solicitud de cashout.
 
+
+## 🛠️ Troubleshooting (Codex patch conflict)
+
+Si una tarea de Codex falla con el error:
+
+> `Failed to apply patch ... setup script and agent modify the same files`
+
+usa este flujo para recuperar la rama y reintentar:
+
+```bash
+# 1) Ver plan (sin tocar nada)
+./scripts/recover-codex-patch-conflict.sh
+
+# 2) Ejecutar limpieza total contra origin/<rama>
+./scripts/recover-codex-patch-conflict.sh --force
+
+# 3) Validar estado local
+npm run check
+```
+
+> ⚠️ `--force` elimina cambios no comiteados y archivos no trackeados.
+
 ## 📁 Estructura del Proyecto
 
 ```

--- a/index.html
+++ b/index.html
@@ -687,6 +687,9 @@
 
 
         (function () {
+            if (window.MTR_INLINE_TOP_STREAMS_ACTIVE) {
+                return;
+            }
             if (window.__MTR_TOP_STREAMS_EXTERNAL__) {
                 return;
             }

--- a/scripts/recover-codex-patch-conflict.sh
+++ b/scripts/recover-codex-patch-conflict.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Uso:
+  scripts/recover-codex-patch-conflict.sh [--force]
+
+Qué hace:
+  - Detecta la rama actual.
+  - Muestra los comandos de recuperación para conflictos de parche de Codex.
+  - Con --force ejecuta limpieza total del working tree contra origin/<rama>.
+
+Nota:
+  --force es destructivo: elimina cambios no comiteados y archivos no trackeados.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "❌ Este script debe ejecutarse dentro de un repo Git." >&2
+  exit 1
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$branch" == "HEAD" ]]; then
+  echo "❌ No se pudo detectar una rama activa (HEAD detached)." >&2
+  exit 1
+fi
+
+cat <<PLAN
+Rama detectada: $branch
+
+Plan recomendado para cuando Codex falla con:
+  "Failed to apply patch ... setup script and agent modify the same files"
+
+1) Guardar evidencia mínima:
+   git status --short --branch
+   git diff --stat
+
+2) Limpiar repo a remoto y volver a correr tarea:
+   git fetch origin
+   git reset --hard origin/$branch
+   git clean -fd
+
+3) Verificación rápida:
+   npm run check
+PLAN
+
+if [[ "${1:-}" != "--force" ]]; then
+  echo "\nℹ️ Modo simulación. No se hicieron cambios. Usa --force para ejecutar limpieza."
+  exit 0
+fi
+
+echo "\n⚠️ Ejecutando recuperación destructiva..."
+git fetch origin
+git reset --hard "origin/$branch"
+git clean -fd
+
+echo "✅ Repo limpio y sincronizado con origin/$branch"


### PR DESCRIPTION
### Motivation

- Provide an explicit recovery workflow for the Codex patch-apply conflict error `Failed to apply patch ... setup script and agent modify the same files` so the repo can be recovered safely and deterministically. 
- Restore a missing inline guard in the dashboard fallback that caused runtime integrity checks to fail during automated validation.

### Description

- Add `scripts/recover-codex-patch-conflict.sh`, an executable helper that shows a safe recovery plan and can run a destructive `fetch + reset --hard + clean -fd` against `origin/<branch>` when invoked with `--force`.
- Document the recovery flow in `README.md` under a new "Troubleshooting (Codex patch conflict)" section with usage examples for `./scripts/recover-codex-patch-conflict.sh` and `npm run check`.
- Restore the inline early-return guard `if (window.MTR_INLINE_TOP_STREAMS_ACTIVE) { return; }` in `index.html` so the runtime integrity script finds the expected guard.

### Testing

- Ran `npm run check` which initially failed with `MISSING_INLINE_DASHBOARD_GUARD` before the `index.html` change. 
- After restoring the guard and adding the recovery script and README entry, `npm run check` completed successfully and the runtime integrity script printed `runtime-integrity-ok`.
- The `node --check` validations for `app.js` and fallback scripts are included in `npm run check` and passed as part of the successful run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20e2144e0832d91582ee7c1300bdb)