### PR TITLE
Add MTR deposit credit UI and flow with safe rollout checklist

### DIFF
--- a/SAFE_ROLLOUT_CHECKLIST.md
+++ b/SAFE_ROLLOUT_CHECKLIST.md
@@ -1,0 +1,42 @@
+# Safe rollout checklist for MTR deposit credit flow
+
+Use this checklist before merging/deploying the `Acreditar compra` flow.
+
+## 1) Pre-merge (local)
+- [ ] Open `index.html` and verify both elements exist:
+  - `#depositTxHash`
+  - `#creditPurchaseBtn`
+- [ ] Run syntax/runtime checks:
+  - `npm run check`
+- [ ] Confirm `creditPurchasedMtr()` still calls:
+  - `GameEngine.verifyDepositAndCredit(txHash, { network: 'base' })`
+
+## 2) Manual functional test (staging)
+- [ ] Open app and navigate to **Comprar MTR directo** panel.
+- [ ] Paste invalid hash (example: `0x123`) and click **Acreditar compra**.
+  - Expected: validation toast error appears.
+- [ ] Paste valid-format hash (`0x` + 64 hex chars) and click button.
+  - Expected: button disables while request is in-flight.
+  - Expected: button re-enables after response.
+- [ ] If backend responds with credited/newBalance:
+  - Expected: success toast appears and input is cleared.
+- [ ] If backend responds with status only:
+  - Expected: info toast with status appears.
+
+## 3) Regression checks
+- [ ] Quick match still blocks when in-app balance is insufficient.
+- [ ] Quick match allows play after a successful credited deposit.
+- [ ] Cashout quote/request buttons still work as before.
+
+## 4) Production rollout guardrails
+- [ ] Deploy in low-traffic window.
+- [ ] Monitor backend `/api/deposits/verify` 4xx/5xx and latency for 30 minutes.
+- [ ] Monitor frontend console errors for `creditPurchasedMtr` and wallet flows.
+- [ ] Keep rollback commit hash ready.
+
+## 5) Rollback criteria
+Rollback if any of the following happen:
+- [ ] Credit button stuck disabled.
+- [ ] Verification request not sent for valid tx hash.
+- [ ] Spike in failed credits or user reports of unable-to-bet after purchase.
+

--- a/index.html
+++ b/index.html
@@ -236,20 +236,15 @@
                     <div class="settlement-card">
                         <h4>Comprar MTR directo</h4>
                         <p class="settlement-help">
-                            Compra MTR en Aerodrome y vuelve aquí: el saldo se actualiza automáticamente al conectar tu wallet en Base.
+                            Compra MTR en Aerodrome y vuelve aquí. Después registra el hash en "Acreditar compra" para sumar saldo jugable.
                         </p>
                         <div class="settlement-grid">
                             <a class="btn-primary" target="_blank" rel="noopener noreferrer" href="https://aerodrome.finance/swap?from=ETH&to=0x99cd1eb32846c9027ed9cb8710066fa08791c33b">Comprar MTR en Aerodrome</a>
- codex/migrate-mtoken-to-mtr-on-base-chain-cp11cg
                             <p class="settlement-help">Contrato oficial MTR en Base (checksum validado).</p>
                             <a class="btn-secondary" target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">🔎 Ver token MTR y supply en Basescan</a>
-
- codex/migrate-mtoken-to-mtr-on-base-chain-9f5qe8
                             <p class="settlement-help">Contrato MTR: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
-
-                            <p class="settlement-help">Contrato MTR: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
- feature/wall-street-v2
- feature/wall-street-v2
+                            <input id="depositTxHash" class="payment-input" type="text" placeholder="Pega el hash de compra (0x...)" autocomplete="off">
+                            <button type="button" class="btn-secondary" id="creditPurchaseBtn" onclick="creditPurchasedMtr()">✅ Acreditar compra</button>
                         </div>
                         
                     </div>
@@ -274,21 +269,11 @@
                 <div class="settlement-card">
                     <p>Token ERC-20 en Base. Liquidez lockeada en Aerodrome.</p>
                     <p>Contrato: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b.</p>
- codex/migrate-mtoken-to-mtr-on-base-chain-cp11cg
                     <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR.</p>
                     <div class="settlement-grid">
                         <a class="btn-primary" target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">📈 Ver token MTR en Basescan</a>
                         <p class="settlement-help">Este botón abre el explorer del token para ver supply, holders y transacciones.</p>
                     </div>
-
- codex/migrate-mtoken-to-mtr-on-base-chain-9f5qe8
-                    <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR (<a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">ver en Basescan</a>)</p>
-                    <p>Explorer: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
-
-                    <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR (<a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">ver en Basescan</a>)</p>
-                    <p>Explorer: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
- feature/wall-street-v2
- feature/wall-street-v2
                 </div>
             </section>
 
@@ -1253,7 +1238,40 @@
                 showToast(`Retiro solicitado: ${payout.requestId || 'ID pendiente'}`, 'success');
             }
         }
+
+        function isBaseTxHash(value) {
+            return /^0x([A-Fa-f0-9]{64})$/.test(value || '');
+        }
+
+        async function creditPurchasedMtr() {
+            const txInput = document.getElementById('depositTxHash');
+            const creditButton = document.getElementById('creditPurchaseBtn');
+            const txHash = txInput?.value?.trim();
+            if (!isBaseTxHash(txHash)) {
+                showToast('Pega un hash válido de Base (0x + 64 caracteres hex)', 'error');
+                return;
+            }
+            if (typeof GameEngine === 'undefined') {
+                showToast('GameEngine no está cargado', 'error');
+                return;
+            }
+
+            if (creditButton) creditButton.disabled = true;
+            try {
+                const result = await GameEngine.verifyDepositAndCredit(txHash, { network: 'base' });
+                if (result?.credited || typeof result?.newBalance === 'number') {
+                    showToast('Compra acreditada. Ya puedes usar tu saldo en partidas pagadas.', 'success');
+                    if (txInput) txInput.value = '';
+                } else if (result?.status) {
+                    showToast(`Estado de verificación: ${result.status}`, 'info');
+                }
+            } finally {
+                if (creditButton) creditButton.disabled = false;
+            }
+        }
+
         window.showIncomingChallenge = showIncomingChallenge;
+        window.creditPurchasedMtr = creditPurchasedMtr;
     </script>
 
     <script type="module">


### PR DESCRIPTION
### Motivation
- Provide a simple UI and client-side flow to let users register a Base purchase transaction hash and credit their in-app MTR balance. 
- Add a safe-rollout checklist to reduce risk during staging/production deployment and ensure manual/regression checks are followed.

### Description
- Add input `#depositTxHash` and button `#creditPurchaseBtn` in `index.html` and update copy to instruct users to paste the purchase hash. 
- Implement `isBaseTxHash` validation and `creditPurchasedMtr` function that validates the hash, disables the button while calling `GameEngine.verifyDepositAndCredit(txHash, { network: 'base' })`, shows toasts for success/info/error, and clears the input on success. 
- Expose `creditPurchasedMtr` on `window` and keep integration with existing `GameEngine` behavior, and remove stray codex/comment fragments from the markup. 
- Add `SAFE_ROLLOUT_CHECKLIST.md` with pre-merge, staging, regression, rollout guardrails, and rollback criteria.

### Testing
- Ran static/runtime checks via `npm run check` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a259b078cc832d9331ae49183e8b1a)