### PR TITLE
Add deposit verification UI, on-chain MTR balance checks, token address/config fixes and rollout guards

### DIFF
--- a/SAFE_ROLLOUT_CHECKLIST.md
+++ b/SAFE_ROLLOUT_CHECKLIST.md
@@ -1,0 +1,52 @@
+# Safe rollout checklist for MTR automatic deposit verification flow
+
+Use this checklist before merging/deploying the `Verificar depósito` flow.
+
+## 1) Pre-merge (local)
+- [ ] Open `index.html` and verify both elements exist:
+  - `#depositTxHash`
+  - `#creditPurchaseBtn` (label: `🔎 Verificar depósito`)
+- [ ] Run syntax/runtime checks:
+  - `npm run check`
+- [ ] Run pre-push guard (no conflict markers + checks):
+  - `npm run prepush:guard`
+- [ ] Confirm `verifyPurchasedMtrTx()` calls:
+  - `GameEngine.verifyDepositAndCredit(txHash, { network: 'base' })`
+- [ ] Confirm no manual credit text remains in UI (`Acreditar compra`).
+
+## 2) Manual functional test (staging)
+- [ ] Open app and navigate to **Comprar MTR directo** panel.
+- [ ] Paste invalid hash (example: `0x123`) and click **Verificar depósito**.
+  - Expected: validation toast error appears.
+- [ ] Paste valid-format hash (`0x` + 64 hex chars) and click button.
+  - Expected: button disables while request is in-flight.
+  - Expected: button re-enables after response.
+- [ ] If backend responds with credited/newBalance:
+  - Expected: success toast appears and input is cleared.
+- [ ] If backend responds with status only:
+  - Expected: info toast with on-chain verification status appears.
+
+## 3) Wallet/Base network checks
+- [ ] Connect wallet on Base:
+  - Expected: warning banner hidden, button text `Wallet conectada`.
+- [ ] Connect wallet on non-Base chain:
+  - Expected: warning banner visible and button text `Cambiar a Base`.
+- [ ] Disconnect wallet:
+  - Expected: on-chain badge shows explicit state (`Wallet no conectada`).
+
+## 4) Regression checks
+- [ ] Quick match still blocks when in-app balance is insufficient.
+- [ ] Quick match allows play after successful verified deposit.
+- [ ] Cashout quote/request buttons still work as before.
+
+## 5) Production rollout guardrails
+- [ ] Deploy in low-traffic window.
+- [ ] Monitor backend `/api/deposits/verify` 4xx/5xx and latency for 30 minutes.
+- [ ] Monitor frontend console errors for `verifyPurchasedMtrTx` and wallet/Base flows.
+- [ ] Keep rollback commit hash ready.
+
+## 6) Rollback criteria
+Rollback if any of the following happen:
+- [ ] Verify button stuck disabled.
+- [ ] Verification request not sent for valid tx hash.
+- [ ] Spike in failed verifications or user reports of unable-to-bet after purchase.

--- a/backend/prize-service.js
+++ b/backend/prize-service.js
@@ -6,7 +6,7 @@ const { createPublicClient, createWalletClient, http, parseUnits } = require('vi
 const { privateKeyToAccount } = require('viem/accounts');
 const { base } = require('viem/chains');
 
-const MTR_TOKEN_ADDRESS = '0x99cd1eb32846c9027ed9cb8710066fa08791c33b';
+const MTR_TOKEN_ADDRESS = process.env.MTR_TOKEN_ADDRESS || '0x99cd1eb32846c9027ed9cb88710066fa08791c33b';
 const ERC20_ABI = [
   {
     type: 'function',

--- a/config/config.js
+++ b/config/config.js
@@ -9,7 +9,7 @@ const CONFIG = {
     
     // Smart Contracts (actualizar después del deploy)
     CONTRACT_ADDRESS: '0xYourBattleContractAddress',
-    TOKEN_ADDRESS: '0x99cd1eb32846c9027ed9cb8710066fa08791c33b',
+    TOKEN_ADDRESS: '0x99cd1eb32846c9027ed9cb88710066fa08791c33b',
     
     // App Configuration
     BATTLE_DURATION: 60,  // segundos

--- a/game-engine.js
+++ b/game-engine.js
@@ -150,9 +150,9 @@ const GameEngine = {
     },
     
     updateBalanceDisplay() {
-        const balanceEl = document.getElementById('balanceDisplay');
+        const balanceEl = document.getElementById('appBalanceDisplay');
         if (balanceEl) {
-            balanceEl.textContent = `💰 ${this.userBalance} MTR`;
+            balanceEl.textContent = `Saldo jugable: ${this.userBalance} MTR`;
         }
         const userBalanceEl = document.getElementById('userBalance');
         if (userBalanceEl) {
@@ -1072,7 +1072,7 @@ const GameEngine = {
                         <p>Billetera plataforma: ${platformWallet}</p>
                     </div>
                 ` : ''}
-                ${this.lastPrizeTxHash ? `<p class="victory-prize">✅ Premio enviado! Tx: <a href="https://basescan.org/tx/${this.lastPrizeTxHash}" target="_blank" rel="noopener noreferrer">Ver en Basescan</a></p>` : ''}
+                ${this.lastPrizeTxHash ? `<p class="victory-prize">Premio enviado! Tx: <a href="https://basescan.org/tx/${this.lastPrizeTxHash}" target="_blank" rel="noopener noreferrer">${this.lastPrizeTxHash}</a></p>` : ''}
                 <button onclick="${match.match_type === 'practice' ? 'GameEngine.goToPracticeSelection()' : 'location.reload()'}" class="btn-primary btn-large">
                     ${match.match_type === 'practice' ? 'Continuar en práctica' : 'Jugar de Nuevo'}
                 </button>
@@ -1713,6 +1713,7 @@ const GameEngine = {
             });
             if (data?.txHash) {
                 this.lastPrizeTxHash = data.txHash;
+                showToast(`Premio enviado! Tx: ${data.txHash.slice(0, 10)}...`, 'success');
                 console.log('[prize] Prize tx hash', data.txHash);
             }
             return data;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <meta name="mtr-build" content="20260227mtr">
+    <meta name="mtr-build" content="20260228mtr2">
     <title>MusicToken Ring - Music Battle Arena</title>
    
     <!-- Fonts -->
@@ -15,9 +15,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
    
     <!-- Styles -->
-    <link rel="stylesheet" href="./styles/main.css">
+    <link rel="stylesheet" href="./styles/main.css?v=20260228mtr2">
    
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🥊</text></svg>">
+    <link rel="icon" type="image/png" href="https://pink-blank-vicuna-260.mypinata.cloud/ipfs/bafybeie24pisqmw6teijdng4flzjwumgwpesilowjxq3kww3p7kxlmuywm">
 
     <!-- Supabase JS -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -27,7 +27,8 @@
             SUPABASE_URL: 'https://bscmgcnynbxalcuwdqlm.supabase.co',
             SUPABASE_ANON_KEY: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJzY21nY255bmJ4YWxjdXdkcWxtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzA0NTYwOTUsImV4cCI6MjA4NjAzMjA5NX0.1iasFQ5H0GmrFqi6poWNE1aZOtbmQuB113RCyg2BBK4',
             BATTLE_DURATION: 60,
-            BACKEND_API: 'https://musictoken-backend.onrender.com'
+            BACKEND_API: 'https://musictoken-backend.onrender.com',
+            MTR_TOKEN_ADDRESS: window.MTR_TOKEN_ADDRESS || '0x99cd1eb32846c9027ed9cb88710066fa08791c33b'
         };
         function extractMetaMaskErrorMessage(reason) {
             if (!reason) return '';
@@ -52,9 +53,9 @@
         });
 
         const PLATFORM_WALLET_ADDRESSES = {
-            base: '0x75376BC58830f27415402875D26B73A6BE8E2253'
+            base: window.PLATFORM_WALLET_BASE_ADDRESS || '0x75376BC58830f27415402875D26B73A6BE8E2253'
         };
-        window.MTR_BUILD_ID = '20260227mtr';
+        window.MTR_BUILD_ID = '20260228mtr2';
 
         // Critical UI fallbacks: keep mode buttons functional even if a later script fails to parse/load.
         if (typeof window.selectMode !== 'function') {
@@ -88,6 +89,85 @@
 
         console.log('🎵 MusicToken Ring loaded! build=' + window.MTR_BUILD_ID);
     </script>
+
+    <script>
+        function shouldBlockRenderedString(value) {
+            if (!value) return false;
+            return /(codex\/|refs\/heads\/)/i.test(String(value));
+        }
+
+        function pruneForbiddenTextNodes(root = document.body) {
+            if (!root) return;
+            const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+            const nodes = [];
+            while (walker.nextNode()) nodes.push(walker.currentNode);
+            nodes.forEach((node) => {
+                if (!node || !node.parentElement) return;
+                const parentTag = node.parentElement.tagName;
+                if (parentTag === 'SCRIPT' || parentTag === 'STYLE') return;
+                const raw = (node.nodeValue || '').trim();
+                if (!raw) return;
+                if (shouldBlockRenderedString(raw)) {
+                    node.remove();
+                }
+            });
+        }
+
+        function normalizeCriticalSectionsOnce(root = document.body) {
+            if (!root) return;
+            const keepFirst = (selector) => {
+                const nodes = root.querySelectorAll(selector);
+                nodes.forEach((n, idx) => { if (idx > 0) n.remove(); });
+            };
+
+            keepFirst('#creditPurchaseBtn');
+            keepFirst('#depositTxHash');
+            keepFirst('.about-mtr-card img.mtr-logo-large');
+            keepFirst('.header .logo img.logo-icon');
+            keepFirst('.header .logo .logo-text');
+            keepFirst('#onchainBalanceDisplay');
+            keepFirst('#appBalanceDisplay');
+            keepFirst('#walletNetworkWarning');
+            keepFirst('.about-mtr-card');
+
+            const firstSettlement = root.querySelector('.settlement-panel .settlement-card');
+            if (firstSettlement) {
+                ['a[href*="aerodrome.finance/swap"]', 'a[href*="basescan.org/address/"]', 'a[href*="basescan.org/token/"]'].forEach((sel) => {
+                    const nodes = firstSettlement.querySelectorAll(sel);
+                    nodes.forEach((n, idx) => { if (idx > 0) n.remove(); });
+                });
+            }
+
+            const aboutCard = root.querySelector('.about-mtr-card');
+            if (aboutCard) {
+                const seen = new Set();
+                aboutCard.querySelectorAll('p').forEach((p) => {
+                    const key = (p.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase();
+                    if (!key || seen.has(key)) p.remove();
+                    else seen.add(key);
+                });
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            pruneForbiddenTextNodes(document.body);
+            normalizeCriticalSectionsOnce(document.body);
+            const observer = new MutationObserver(() => {
+                pruneForbiddenTextNodes(document.body);
+                normalizeCriticalSectionsOnce(document.body);
+            });
+            observer.observe(document.body, { childList: true, subtree: true });
+        });
+    </script>
+
+    <style>
+        /* Fallback styles to avoid broken/plain rendering if cached CSS is stale */
+        .btn-link-primary{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 14px;border-radius:10px;color:#fff;text-decoration:none;font-weight:700;background:#2563eb;box-shadow:0 8px 20px rgba(37,99,235,.35)}
+        .btn-link-primary:hover{background:#1d4ed8}
+        .w-12{width:48px}.h-12{height:48px}.rounded-full{border-radius:9999px}.w-5{width:20px}.h-5{height:20px}
+        .mtr-logo-large{width:110px;height:110px;border-radius:9999px;object-fit:cover}
+    </style>
+
 </head>
 <body>
     <!-- Header -->
@@ -95,7 +175,7 @@
         <div class="container">
             <div class="header-content">
                 <div class="logo">
-                    <span class="logo-icon">🥊</span>
+                    <img src="https://pink-blank-vicuna-260.mypinata.cloud/ipfs/bafybeiah2fffgw6y6aomfx5b5pgav7wedo3qdtqxqteg2glvmgzs6fpivu" alt="MTR Logo" class="logo-icon w-12 h-12 rounded-full" onerror="this.style.display='none'">
                     <span class="logo-text">MusicToken Ring</span>
                 </div>
                 <h2 class="slogan">Music Token Ring – The Wall Street of Beats</h2>
@@ -103,7 +183,8 @@
                 <div class="header-badges">
                     <span class="badge">🎵 Deezer</span>
                     <span class="badge badge-live">🔴 Live</span>
-                    <span class="badge" id="balanceDisplay">Tu MTR: --</span>
+                    <span class="badge" id="onchainBalanceDisplay">On-chain: --</span>
+                    <span class="badge" id="appBalanceDisplay">Jugable: --</span>
                 </div>
 
                 <div class="wallet-section">
@@ -112,6 +193,9 @@
                     </button>
                     <span id="walletAddress" class="wallet-address hidden"></span>
                 </div>
+                <p id="walletNetworkWarning" class="wallet-network-warning hidden">
+                    ⚠️ Red incorrecta. Cambia a Base (8453) para jugar y verificar depósitos.
+                </p>
                 
                 <!-- AUTH BUTTON -->
                 <div id="authButton">
@@ -236,20 +320,25 @@
                     <div class="settlement-card">
                         <h4>Comprar MTR directo</h4>
                         <p class="settlement-help">
-                            Compra MTR en Aerodrome y vuelve aquí: el saldo se actualiza automáticamente al conectar tu wallet en Base.
+                            Compra MTR en Aerodrome y vuelve aquí. El saldo jugable solo se habilita tras verificación on-chain/backend del hash en Base.
                         </p>
                         <div class="settlement-grid">
-                            <a class="btn-primary" target="_blank" rel="noopener noreferrer" href="https://aerodrome.finance/swap?from=ETH&to=0x99cd1eb32846c9027ed9cb8710066fa08791c33b">Comprar MTR en Aerodrome</a>
- codex/migrate-mtoken-to-mtr-on-base-chain-cp11cg
-                            <p class="settlement-help">Contrato oficial MTR en Base (checksum validado).</p>
-                            <a class="btn-secondary" target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">🔎 Ver token MTR y supply en Basescan</a>
-
- codex/migrate-mtoken-to-mtr-on-base-chain-9f5qe8
-                            <p class="settlement-help">Contrato MTR: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
-
-                            <p class="settlement-help">Contrato MTR: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
- feature/wall-street-v2
- feature/wall-street-v2
+                            <a class="btn-primary btn-link-primary bg-blue-600 hover:bg-blue-700 shadow" target="_blank" rel="noopener noreferrer" href="https://aerodrome.finance/swap?from=ETH&to=0x99cd1eb32846c9027ed9cb88710066fa08791c33b">
+                                <svg class="link-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                                Jugar Ahora
+                            </a>
+                            <a class="btn-primary btn-link-primary bg-blue-600 hover:bg-blue-700 shadow" target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb88710066fa08791c33b">
+                                <svg class="link-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                                Ver Contrato en Basescan
+                            </a>
+                            <a class="btn-primary btn-link-primary bg-blue-600 hover:bg-blue-700 shadow" target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb88710066fa08791c33b">
+                                <svg class="link-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                                Ver Supply 99.99M MTR
+                            </a>
+                            <p class="settlement-help">Contrato MTR: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb88710066fa08791c33b">0x99cd1eb32846c9027ed9cb88710066fa08791c33b</a></p>
+                            <p class="settlement-help" id="tokenConfigError" style="color:#ff6b6b;display:none;"></p>
+                            <input id="depositTxHash" class="payment-input" type="text" placeholder="Pega hash de compra en Base (0x...)" autocomplete="off">
+                            <button type="button" class="btn-secondary" id="creditPurchaseBtn" onclick="verifyPurchasedMtrTx()">🔎 Verificar depósito</button>
                         </div>
                         
                     </div>
@@ -271,24 +360,11 @@
 
             <section class="payments-showcase">
                 <p class="streaming-label">Sobre MTR</p>
-                <div class="settlement-card">
+                <div class="settlement-card about-mtr-card">
+                    <img src="https://pink-blank-vicuna-260.mypinata.cloud/ipfs/bafybeiah2fffgw6y6aomfx5b5pgav7wedo3qdtqxqteg2glvmgzs6fpivu" alt="MTR Logo" class="mtr-logo-large" onerror="this.style.display='none'">
                     <p>Token ERC-20 en Base. Liquidez lockeada en Aerodrome.</p>
-                    <p>Contrato: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b.</p>
- codex/migrate-mtoken-to-mtr-on-base-chain-cp11cg
-                    <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR.</p>
-                    <div class="settlement-grid">
-                        <a class="btn-primary" target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">📈 Ver token MTR en Basescan</a>
-                        <p class="settlement-help">Este botón abre el explorer del token para ver supply, holders y transacciones.</p>
-                    </div>
-
- codex/migrate-mtoken-to-mtr-on-base-chain-9f5qe8
-                    <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR (<a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">ver en Basescan</a>)</p>
-                    <p>Explorer: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
-
-                    <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR (<a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">ver en Basescan</a>)</p>
-                    <p>Explorer: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
- feature/wall-street-v2
- feature/wall-street-v2
+                    <p>Contrato verificado: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb88710066fa08791c33b">0x99cd1eb32846c9027ed9cb88710066fa08791c33b</a></p>
+                    <p>Supply total: 99,990,000 MTR (99.99M).</p>
                 </div>
             </section>
 
@@ -400,7 +476,8 @@
                         <div class="bet-section">
                             <h3>💰 Tu Apuesta</h3>
                             <div class="bet-info">
-                                <span><span id="balanceLabel">Tu MTR</span>: <strong id="userBalance">0</strong> MTR</span>
+                                <span><span id="balanceLabel">Tu MTR (on-chain)</span>: <strong id="onchainMtrBalance">--</strong> MTR</span>
+                                <span>Saldo jugable: <strong id="userBalance">0</strong> MTR</span>
                                 <span>Mínimo: <strong id="minBet">100</strong> MTR</span>
                             </div>
                             <input 
@@ -689,11 +766,11 @@
     </footer>
 
     <!-- Scripts -->
-    <script src="./auth-system.js"></script>
-    <script src="./game-engine.js"></script>
+    <script src="./auth-system.js?v=20260228mtr2"></script>
+    <script src="./game-engine.js?v=20260228mtr2"></script>
     <script>window.MTR_INLINE_TOP_STREAMS_ACTIVE = true;</script>
-    <script src="./app.js?v=20260227mtr"></script>
-    <script src="./top-streams-fallback.js?v=20260227mtr"></script>
+    <script src="./app.js?v=20260228mtr2"></script>
+    <script src="./top-streams-fallback.js?v=20260228mtr2"></script>
 
 
 
@@ -867,6 +944,7 @@
         })();
         // Variables globales
         let selectedSong = null;
+        window.__mtrOnChainBalance = Number(window.__mtrOnChainBalance || 0);
         let currentMode = null;
 
 
@@ -898,7 +976,7 @@
                 }
 
                 const roomParam = urlParams.get('room');
-                if (roomParam) {
+                    if (roomParam) {
                     selectMode('private');
                     document.getElementById('joinRoomCode').value = roomParam.toUpperCase();
                     showToast('Sala privada detectada. Selecciona tu canción para unirte.', 'info');
@@ -979,6 +1057,9 @@
                 </div>
             `;
         }
+        function sanitizeInjectedGitArtifactsPage() {
+            pruneForbiddenTextNodes(document.body);
+        }
 
         // Seleccionar modo
         function selectMode(mode) {
@@ -1021,6 +1102,9 @@
                         ⚔️ Buscar Rival
                     </button>
                 `;
+                const startQuickBtn = document.getElementById('startQuickBtn');
+                if (startQuickBtn) startQuickBtn.dataset.baseState = 'ready';
+                updateBetEligibility();
             } else if (mode === 'private') {
                 buttonsDiv.innerHTML = `
                     <button type="button" onclick="createRoom()" class="btn-primary" id="createRoomBtn" disabled>
@@ -1089,17 +1173,45 @@
                     btn.disabled = false;
                 }
             });
+            updateBetEligibility();
         }
 
         // Apuesta rápida
         function quickBet(amount) {
             document.getElementById('betAmount').value = amount;
+            updateBetEligibility();
+        }
+
+
+        function updateBetEligibility() {
+            const startQuickBtn = document.getElementById('startQuickBtn');
+            const betAmountEl = document.getElementById('betAmount');
+            const onchainBalance = Number(window.__mtrOnChainBalance || 0);
+            const bet = parseFloat(betAmountEl?.value || '0');
+            if (!startQuickBtn) return;
+
+            const canCoverBet = !!bet && onchainBalance >= bet;
+            if (startQuickBtn.dataset.baseState === 'ready') {
+                startQuickBtn.disabled = !canCoverBet;
+            }
+
+            if (!canCoverBet && bet > 0) {
+                startQuickBtn.title = 'Saldo on-chain insuficiente para la apuesta';
+            } else {
+                startQuickBtn.title = '';
+            }
         }
 
         // Iniciar según modo
         async function startQuickMatch() {
             if (!selectedSong) return;
             const bet = parseInt(document.getElementById('betAmount').value) || 100;
+            const onchainBalance = Number(window.__mtrOnChainBalance || 0);
+            if (onchainBalance < bet) {
+                showToast('Saldo on-chain insuficiente para esta apuesta', 'error');
+                updateBetEligibility();
+                return;
+            }
             if (typeof GameEngine !== 'undefined') {
                 await GameEngine.joinQuickMatch(selectedSong, bet);
             } else {
@@ -1253,75 +1365,171 @@
                 showToast(`Retiro solicitado: ${payout.requestId || 'ID pendiente'}`, 'success');
             }
         }
+
+        function isBaseTxHash(value) {
+            return /^0x([A-Fa-f0-9]{64})$/.test(value || '');
+        }
+
+        async function verifyPurchasedMtrTx() {
+            const txInput = document.getElementById('depositTxHash');
+            const creditButton = document.getElementById('creditPurchaseBtn');
+            const txHash = txInput?.value?.trim();
+            if (!isBaseTxHash(txHash)) {
+                showToast('Pega un hash válido de Base (0x + 64 caracteres hex)', 'error');
+                return;
+            }
+            if (typeof GameEngine === 'undefined') {
+                showToast('GameEngine no está cargado', 'error');
+                return;
+            }
+
+            if (creditButton) creditButton.disabled = true;
+            try {
+                const result = await GameEngine.verifyDepositAndCredit(txHash, { network: 'base' });
+                if (result?.credited || typeof result?.newBalance === 'number') {
+                    showToast('Depósito verificado y acreditado. Ya puedes usar tu saldo en partidas pagadas.', 'success');
+                    if (txInput) txInput.value = '';
+                } else if (result?.status) {
+                    showToast(`Estado de verificación on-chain: ${result.status}`, 'info');
+                }
+            } finally {
+                if (creditButton) creditButton.disabled = false;
+            }
+        }
+
+        const betAmountInput = document.getElementById('betAmount');
+        if (betAmountInput) betAmountInput.addEventListener('input', updateBetEligibility);
+
         window.showIncomingChallenge = showIncomingChallenge;
+        window.verifyPurchasedMtrTx = verifyPurchasedMtrTx;
+        window.updateBetEligibility = updateBetEligibility;
     </script>
 
     <script type="module">
-        import { createConfig, http, connect, getAccount, watchAccount, reconnect, readContract } from 'https://esm.sh/@wagmi/core';
-        import { base } from 'https://esm.sh/wagmi/chains';
-        import { injected } from 'https://esm.sh/@wagmi/connectors';
-        import { walletConnect } from 'https://esm.sh/@wagmi/connectors';
-        import { formatUnits } from 'https://esm.sh/viem';
+        import { createPublicClient, createWalletClient, custom, http, formatUnits, isAddress, getAddress } from 'https://esm.sh/viem';
+        import { base } from 'https://esm.sh/viem/chains';
 
-        const MTR_TOKEN = '0x99cd1eb32846c9027ed9cb8710066fa08791c33b';
-        const ERC20_ABI = [
-            { type: 'function', name: 'balanceOf', stateMutability: 'view', inputs: [{ name: 'account', type: 'address' }], outputs: [{ name: '', type: 'uint256' }] }
-        ];
+        const EXPECTED_MTR_TOKEN = '0x99cd1eb32846c9027ed9cb88710066fa08791c33b';
+        const MTR_TOKEN = window.CONFIG?.MTR_TOKEN_ADDRESS || EXPECTED_MTR_TOKEN;
+        const publicClient = createPublicClient({ chain: base, transport: http('https://mainnet.base.org') });
 
-        const wagmiConfig = createConfig({
-            chains: [base],
-            connectors: [
-                injected({ target: 'metaMask' }),
-                walletConnect({ projectId: window.WALLETCONNECT_PROJECT_ID || 'demo-project-id' })
-            ],
-            transports: {
-                [base.id]: http('https://mainnet.base.org')
+        let connectedAddress = null;
+        let connectedChainId = null;
+
+        function setOnchainBalanceError(label = 'Error RPC') {
+            const badge = document.getElementById('onchainBalanceDisplay');
+            const onchainBalance = document.getElementById('onchainMtrBalance');
+            if (badge) badge.textContent = `On-chain: ${label}`;
+            if (onchainBalance) onchainBalance.textContent = label;
+        }
+
+        function validateMtrTokenAddress() {
+            const errorEl = document.getElementById('tokenConfigError');
+            if (!isAddress(MTR_TOKEN)) {
+                if (errorEl) {
+                    errorEl.textContent = 'Error crítico: la address MTR configurada es inválida.';
+                    errorEl.style.display = 'block';
+                }
+                return false;
             }
-        });
+            const checksummed = getAddress(MTR_TOKEN);
+            if (checksummed.toLowerCase() !== EXPECTED_MTR_TOKEN.toLowerCase()) {
+                if (errorEl) {
+                    errorEl.textContent = `Error crítico: address MTR no permitida (${checksummed}).`;
+                    errorEl.style.display = 'block';
+                }
+                return false;
+            }
+            if (errorEl) errorEl.style.display = 'none';
+            return true;
+        }
+
+        async function ensureBaseChain() {
+            if (!window.ethereum) {
+                if (typeof showToast === 'function') showToast('Instala MetaMask para usar wallet en Base', 'error');
+                return false;
+            }
+            const chainHex = await window.ethereum.request({ method: 'eth_chainId' });
+            const chainId = Number.parseInt(chainHex, 16);
+            connectedChainId = chainId;
+            if (chainId === 8453) return true;
+
+            if (typeof showToast === 'function') showToast('Cambia a Base para MTR', 'error');
+            try {
+                await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: '0x2105' }] });
+                connectedChainId = 8453;
+                return true;
+            } catch (error) {
+                console.warn('[wallet] switch to base rejected', error);
+                return false;
+            }
+        }
 
         async function refreshMtrBalance(address) {
             if (!address) return;
+            if (!validateMtrTokenAddress()) {
+                setOnchainBalanceError('Address inválida');
+                if (typeof showToast === 'function') showToast('Address MTR inválida. Contacta soporte.', 'error');
+                return;
+            }
             try {
-                console.log('[wallet] reading MTR balance', { address });
-                const balance = await readContract(wagmiConfig, {
+                const balance = await publicClient.readContract({
                     address: MTR_TOKEN,
-                    abi: ERC20_ABI,
+                    abi: [{ type: 'function', name: 'balanceOf', stateMutability: 'view', inputs: [{ name: 'account', type: 'address' }], outputs: [{ name: '', type: 'uint256' }] }],
                     functionName: 'balanceOf',
                     args: [address]
                 });
-                const formatted = Number(formatUnits(balance, 18)).toLocaleString('es-ES', { maximumFractionDigits: 4 });
-                const badge = document.getElementById('balanceDisplay');
-                const userBalance = document.getElementById('userBalance');
+                const numericBalance = Number(formatUnits(balance, 18));
+                window.__mtrOnChainBalance = numericBalance;
+                const formatted = numericBalance.toLocaleString('es-ES', { maximumFractionDigits: 4 });
+                const badge = document.getElementById('onchainBalanceDisplay');
+                const onchainBalance = document.getElementById('onchainMtrBalance');
                 if (badge) badge.textContent = `Tu MTR: ${formatted}`;
-                if (userBalance) userBalance.textContent = formatted;
-                console.log('[wallet] MTR balance updated', { formatted });
+                if (onchainBalance) onchainBalance.textContent = formatted;
+                if (typeof window.updateBetEligibility === 'function') window.updateBetEligibility();
             } catch (error) {
                 console.error('[wallet] balance read error', error);
+                setOnchainBalanceError();
+                if (typeof showToast === 'function') showToast('No se pudo leer balance on-chain (RPC/Base)', 'error');
             }
         }
 
-        function renderWallet(account) {
+        function renderWallet() {
             const walletEl = document.getElementById('walletAddress');
             const btnEl = document.getElementById('walletConnectBtn');
+            const warningEl = document.getElementById('walletNetworkWarning');
             if (!walletEl || !btnEl) return;
-            if (account?.address) {
-                walletEl.textContent = `${account.address.slice(0, 6)}...${account.address.slice(-4)}`;
+
+            if (connectedAddress) {
+                walletEl.textContent = `${connectedAddress.slice(0, 6)}...${connectedAddress.slice(-4)}`;
                 walletEl.classList.remove('hidden');
-                btnEl.textContent = 'Wallet conectada';
-                localStorage.setItem('mtr_wallet', account.address);
-                localStorage.setItem('mtr_wallet_chain', 'base');
-                refreshMtrBalance(account.address);
+                btnEl.textContent = connectedChainId === 8453 ? 'Wallet conectada' : 'Cambiar a Base';
+                if (warningEl) warningEl.classList.toggle('hidden', connectedChainId === 8453);
+                localStorage.setItem('mtr_wallet', connectedAddress);
+                localStorage.setItem('mtr_wallet_chain', String(connectedChainId || 'unknown'));
             } else {
                 walletEl.classList.add('hidden');
                 btnEl.textContent = 'Conectar Wallet';
+                if (warningEl) warningEl.classList.add('hidden');
+                window.__mtrOnChainBalance = 0;
+                setOnchainBalanceError('Wallet no conectada');
             }
         }
 
-        async function connectWalletWagmi() {
+        async function connectWallet() {
+            if (!window.ethereum) {
+                if (typeof showToast === 'function') showToast('MetaMask no está disponible', 'error');
+                return;
+            }
             try {
-                console.log('[wallet] connect requested via wagmi');
-                await connect(wagmiConfig, { connector: injected({ target: 'metaMask' }) });
-                renderWallet(getAccount(wagmiConfig));
+                const walletClient = createWalletClient({ chain: base, transport: custom(window.ethereum) });
+                const [address] = await walletClient.requestAddresses();
+                connectedAddress = address || null;
+                const onBase = await ensureBaseChain();
+                renderWallet();
+                if (connectedAddress && onBase) {
+                    await refreshMtrBalance(connectedAddress);
+                }
             } catch (error) {
                 console.error('[wallet] connect error', error);
                 if (typeof showToast === 'function') showToast('No se pudo conectar la wallet', 'error');
@@ -1329,16 +1537,39 @@
         }
 
         const btn = document.getElementById('walletConnectBtn');
-        if (btn) btn.addEventListener('click', connectWalletWagmi);
+        if (btn) btn.addEventListener('click', connectWallet);
 
-        watchAccount(wagmiConfig, {
-            onChange(account) {
-                renderWallet(account);
+        if (window.ethereum?.on) {
+            window.ethereum.on('accountsChanged', async (accounts) => {
+                connectedAddress = accounts?.[0] || null;
+                const onBase = connectedAddress ? await ensureBaseChain() : false;
+                renderWallet();
+                if (connectedAddress && onBase) await refreshMtrBalance(connectedAddress);
+            });
+            window.ethereum.on('chainChanged', async (chainHex) => {
+                connectedChainId = Number.parseInt(chainHex, 16);
+                if (connectedChainId !== 8453 && typeof showToast === 'function') {
+                    showToast('Cambia a Base para MTR', 'error');
+                }
+                renderWallet();
+                if (connectedAddress && connectedChainId === 8453) await refreshMtrBalance(connectedAddress);
+            });
+        }
+
+        validateMtrTokenAddress();
+        if (window.ethereum) {
+            const accounts = await window.ethereum.request({ method: 'eth_accounts' });
+            connectedAddress = accounts?.[0] || null;
+            if (connectedAddress) {
+                await ensureBaseChain();
+                renderWallet();
+                if (connectedChainId === 8453) await refreshMtrBalance(connectedAddress);
+            } else {
+                renderWallet();
             }
-        });
-
-        await reconnect(wagmiConfig);
-        renderWallet(getAccount(wagmiConfig));
+        } else {
+            renderWallet();
+        }
     </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "description": "Static frontend for MusicToken Ring",
   "scripts": {
-    "build": "echo 'Static site: no build required'",
+    "build": "npm run check",
     "preview": "npx serve .",
-    "check": "node --check app.js && node --check top-streams-fallback.js && node --check src/app.js && node --check src/top-streams-fallback.js && node scripts/verify-runtime-integrity.js"
+    "check": "node --check app.js && node --check top-streams-fallback.js && node --check src/app.js && node --check src/top-streams-fallback.js && node scripts/verify-runtime-integrity.js",
+    "prepush:guard": "bash scripts/prepush-guard.sh"
   }
 }

--- a/scripts/prepush-guard.sh
+++ b/scripts/prepush-guard.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+FILES=(
+  "index.html"
+  "styles/main.css"
+  "game-engine.js"
+  "SAFE_ROLLOUT_CHECKLIST.md"
+  "backend/prize-service.js"
+  "config/config.js"
+)
+
+echo "[guard] Checking conflict markers in critical files..."
+if rg -n '^(<<<<<<<|=======|>>>>>>>)' "${FILES[@]}" >/dev/null 2>&1; then
+  echo "[guard][error] Conflict markers detected in critical files." >&2
+  rg -n '^(<<<<<<<|=======|>>>>>>>)' "${FILES[@]}" || true
+  exit 1
+fi
+
+echo "[guard] Conflict-marker check: OK"
+
+echo "[guard] Running project checks..."
+npm run check
+
+echo "[guard] All checks passed. Safe to push."

--- a/scripts/verify-runtime-integrity.js
+++ b/scripts/verify-runtime-integrity.js
@@ -14,6 +14,8 @@ const blockedPatterns = [
   /codex\/find-reason/gi,
   /feature\/wall-street-v2/gi,
   /codex\/fix-unexpected-token-for-error/gi,
+  /codex\/[a-z0-9._#\/-]+/gi,
+  /refs\/heads\//gi,
   /^(<<<<<<<|=======|>>>>>>>)/gm
 ];
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -66,6 +66,13 @@ body {
     font-size: 32px;
 }
 
+.w-12 { width: 48px; }
+.h-12 { height: 48px; }
+.rounded-full { border-radius: 9999px; }
+.w-5 { width: 20px; }
+.h-5 { height: 20px; }
+.shadow { box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35); }
+
 .logo-text {
     font-size: 24px;
     font-weight: 800;
@@ -541,6 +548,43 @@ body {
     margin: 0;
     color: var(--text-secondary);
     font-size: 12px;
+}
+
+
+.btn-link-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 700;
+    box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bg-blue-600 { background: #2563eb; }
+.bg-blue-600:hover,
+.hover\:bg-blue-700:hover {
+    background: #1d4ed8;
+    transform: translateY(-1px);
+    box-shadow: 0 10px 22px rgba(29, 78, 216, 0.42);
+}
+
+.about-mtr-card {
+    align-items: center;
+    text-align: center;
+}
+
+.mtr-logo-large {
+    width: 110px;
+    height: 110px;
+    border-radius: 9999px;
+    object-fit: cover;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
 }
 .feature-item {
     background: var(--bg-secondary);
@@ -1188,6 +1232,19 @@ body {
 
 .btn-secondary:hover {
     border-color: var(--accent-green);
+}
+
+
+.btn-secondary:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+}
+
+.wallet-network-warning {
+    margin: 8px 0 0;
+    color: #ff6b6b;
+    font-size: 12px;
+    font-weight: 600;
 }
 
 .settlement-grid .btn-primary,

--- a/vercel.json
+++ b/vercel.json
@@ -24,5 +24,6 @@
       "source": "/((?!.*\\.).*)",
       "destination": "/index.html"
     }
-  ]
+  ],
+  "buildCommand": "npm run build"
 }


### PR DESCRIPTION
### Motivation
- Add a safe, verifiable flow to let users paste a Base tx hash to verify and credit purchased MTR on-chain and via backend. 
- Prevent accidental leaks/injected git/codex artifacts in production builds and ensure critical files are free of conflict markers before push. 
- Update MTR token address handling to be configurable and consistent across frontend/backend and improve wallet/on-chain balance UX for Base. 

### Description
- Introduces `SAFE_ROLLOUT_CHECKLIST.md` describing pre-merge, staging, network and rollback guardrails for the `Verificar depósito` flow. 
- Adds UI elements and logic in `index.html` and inline scripts: `#depositTxHash`, `#creditPurchaseBtn`, on-chain vs app balance badges, wallet network warning, `verifyPurchasedMtrTx()` validation and `updateBetEligibility()` gating quick-match based on on-chain balance. 
- Reworks wallet/contract interaction to use `viem` client calls in the page, validates the configured MTR address, reads ERC-20 `balanceOf`, and keeps `window.__mtrOnChainBalance` for eligibility checks and UI updates. 
- Backend and config changes make the token address configurable: `backend/prize-service.js` now reads `MTR_TOKEN_ADDRESS` from `process.env`, and `config/config.js` token constant updated to the new address. 
- Game engine and UI tweaks: `game-engine.js` updates balance element id to `appBalanceDisplay`, changes victory screen tx link to display the full tx hash, and shows a toast when prize requests return a tx. 
- Project safety/tooling updates: adds `scripts/prepush-guard.sh` to block conflict markers and run checks, extends `scripts/verify-runtime-integrity.js` to block codex/ref/git artifacts, updates `package.json` scripts (`build` → `npm run check`, adds `prepush:guard`), adds CSS classes and cache-busting query strings, and sets `vercel.json` `buildCommand`. 

### Testing
- Ran `npm run check` (contains `node --check` on key JS files and runs `scripts/verify-runtime-integrity.js`) and it completed successfully. 
- Executed `node scripts/verify-runtime-integrity.js` directly to validate blocked patterns and script refs and it passed. 
- The new `prepush` guard (`scripts/prepush-guard.sh`) was exercised locally and completed the conflict-marker scan and invoked `npm run check` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a259b078cc832d9331ae49183e8b1a)