### PR TITLE
Add on‑chain deposit verification UI and wallet/Base integration; enforce token config and rollout guards

### DIFF
--- a/SAFE_ROLLOUT_CHECKLIST.md
+++ b/SAFE_ROLLOUT_CHECKLIST.md
@@ -1,0 +1,52 @@
+# Safe rollout checklist for MTR automatic deposit verification flow
+
+Use this checklist before merging/deploying the `Verificar depósito` flow.
+
+## 1) Pre-merge (local)
+- [ ] Open `index.html` and verify both elements exist:
+  - `#depositTxHash`
+  - `#creditPurchaseBtn` (label: `🔎 Verificar depósito`)
+- [ ] Run syntax/runtime checks:
+  - `npm run check`
+- [ ] Run pre-push guard (no conflict markers + checks):
+  - `npm run prepush:guard`
+- [ ] Confirm `verifyPurchasedMtrTx()` calls:
+  - `GameEngine.verifyDepositAndCredit(txHash, { network: 'base' })`
+- [ ] Confirm no manual credit text remains in UI (`Acreditar compra`).
+
+## 2) Manual functional test (staging)
+- [ ] Open app and navigate to **Comprar MTR directo** panel.
+- [ ] Paste invalid hash (example: `0x123`) and click **Verificar depósito**.
+  - Expected: validation toast error appears.
+- [ ] Paste valid-format hash (`0x` + 64 hex chars) and click button.
+  - Expected: button disables while request is in-flight.
+  - Expected: button re-enables after response.
+- [ ] If backend responds with credited/newBalance:
+  - Expected: success toast appears and input is cleared.
+- [ ] If backend responds with status only:
+  - Expected: info toast with on-chain verification status appears.
+
+## 3) Wallet/Base network checks
+- [ ] Connect wallet on Base:
+  - Expected: warning banner hidden, button text `Wallet conectada`.
+- [ ] Connect wallet on non-Base chain:
+  - Expected: warning banner visible and button text `Cambiar a Base`.
+- [ ] Disconnect wallet:
+  - Expected: on-chain badge shows explicit state (`Wallet no conectada`).
+
+## 4) Regression checks
+- [ ] Quick match still blocks when in-app balance is insufficient.
+- [ ] Quick match allows play after successful verified deposit.
+- [ ] Cashout quote/request buttons still work as before.
+
+## 5) Production rollout guardrails
+- [ ] Deploy in low-traffic window.
+- [ ] Monitor backend `/api/deposits/verify` 4xx/5xx and latency for 30 minutes.
+- [ ] Monitor frontend console errors for `verifyPurchasedMtrTx` and wallet/Base flows.
+- [ ] Keep rollback commit hash ready.
+
+## 6) Rollback criteria
+Rollback if any of the following happen:
+- [ ] Verify button stuck disabled.
+- [ ] Verification request not sent for valid tx hash.
+- [ ] Spike in failed verifications or user reports of unable-to-bet after purchase.

--- a/backend/prize-service.js
+++ b/backend/prize-service.js
@@ -6,7 +6,7 @@ const { createPublicClient, createWalletClient, http, parseUnits } = require('vi
 const { privateKeyToAccount } = require('viem/accounts');
 const { base } = require('viem/chains');
 
-const MTR_TOKEN_ADDRESS = '0x99cd1eb32846c9027ed9cb8710066fa08791c33b';
+const MTR_TOKEN_ADDRESS = process.env.MTR_TOKEN_ADDRESS || '0x99cd1eb32846c9027ed9cb88710066fa08791c33b';
 const ERC20_ABI = [
   {
     type: 'function',

--- a/config/config.js
+++ b/config/config.js
@@ -9,7 +9,7 @@ const CONFIG = {
     
     // Smart Contracts (actualizar después del deploy)
     CONTRACT_ADDRESS: '0xYourBattleContractAddress',
-    TOKEN_ADDRESS: '0x99cd1eb32846c9027ed9cb8710066fa08791c33b',
+    TOKEN_ADDRESS: '0x99cd1eb32846c9027ed9cb88710066fa08791c33b',
     
     // App Configuration
     BATTLE_DURATION: 60,  // segundos

--- a/game-engine.js
+++ b/game-engine.js
@@ -150,9 +150,9 @@ const GameEngine = {
     },
     
     updateBalanceDisplay() {
-        const balanceEl = document.getElementById('balanceDisplay');
+        const balanceEl = document.getElementById('appBalanceDisplay');
         if (balanceEl) {
-            balanceEl.textContent = `💰 ${this.userBalance} MTR`;
+            balanceEl.textContent = `Saldo jugable: ${this.userBalance} MTR`;
         }
         const userBalanceEl = document.getElementById('userBalance');
         if (userBalanceEl) {
@@ -1072,7 +1072,7 @@ const GameEngine = {
                         <p>Billetera plataforma: ${platformWallet}</p>
                     </div>
                 ` : ''}
-                ${this.lastPrizeTxHash ? `<p class="victory-prize">✅ Premio enviado! Tx: <a href="https://basescan.org/tx/${this.lastPrizeTxHash}" target="_blank" rel="noopener noreferrer">Ver en Basescan</a></p>` : ''}
+                ${this.lastPrizeTxHash ? `<p class="victory-prize">Premio enviado! Tx: <a href="https://basescan.org/tx/${this.lastPrizeTxHash}" target="_blank" rel="noopener noreferrer">${this.lastPrizeTxHash}</a></p>` : ''}
                 <button onclick="${match.match_type === 'practice' ? 'GameEngine.goToPracticeSelection()' : 'location.reload()'}" class="btn-primary btn-large">
                     ${match.match_type === 'practice' ? 'Continuar en práctica' : 'Jugar de Nuevo'}
                 </button>
@@ -1713,6 +1713,7 @@ const GameEngine = {
             });
             if (data?.txHash) {
                 this.lastPrizeTxHash = data.txHash;
+                showToast(`Premio enviado! Tx: ${data.txHash.slice(0, 10)}...`, 'success');
                 console.log('[prize] Prize tx hash', data.txHash);
             }
             return data;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <meta name="mtr-build" content="20260227mtr">
+    <meta name="mtr-build" content="20260228mtr2">
     <title>MusicToken Ring - Music Battle Arena</title>
    
     <!-- Fonts -->
@@ -15,9 +15,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
    
     <!-- Styles -->
-    <link rel="stylesheet" href="./styles/main.css">
+    <link rel="stylesheet" href="./styles/main.css?v=20260228mtr2">
    
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🥊</text></svg>">
+    <link rel="icon" type="image/png" href="https://pink-blank-vicuna-260.mypinata.cloud/ipfs/bafybeie24pisqmw6teijdng4flzjwumgwpesilowjxq3kww3p7kxlmuywm">
 
     <!-- Supabase JS -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -27,7 +27,8 @@
             SUPABASE_URL: 'https://bscmgcnynbxalcuwdqlm.supabase.co',
             SUPABASE_ANON_KEY: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJzY21nY255bmJ4YWxjdXdkcWxtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzA0NTYwOTUsImV4cCI6MjA4NjAzMjA5NX0.1iasFQ5H0GmrFqi6poWNE1aZOtbmQuB113RCyg2BBK4',
             BATTLE_DURATION: 60,
-            BACKEND_API: 'https://musictoken-backend.onrender.com'
+            BACKEND_API: 'https://musictoken-backend.onrender.com',
+            MTR_TOKEN_ADDRESS: window.MTR_TOKEN_ADDRESS || '0x99cd1eb32846c9027ed9cb88710066fa08791c33b'
         };
         function extractMetaMaskErrorMessage(reason) {
             if (!reason) return '';
@@ -52,9 +53,9 @@
         });
 
         const PLATFORM_WALLET_ADDRESSES = {
-            base: '0x75376BC58830f27415402875D26B73A6BE8E2253'
+            base: window.PLATFORM_WALLET_BASE_ADDRESS || '0x75376BC58830f27415402875D26B73A6BE8E2253'
         };
-        window.MTR_BUILD_ID = '20260227mtr';
+        window.MTR_BUILD_ID = '20260228mtr2';
 
         // Critical UI fallbacks: keep mode buttons functional even if a later script fails to parse/load.
         if (typeof window.selectMode !== 'function') {
@@ -88,6 +89,16 @@
 
         console.log('🎵 MusicToken Ring loaded! build=' + window.MTR_BUILD_ID);
     </script>
+
+    
+    <style>
+        /* Fallback styles to avoid broken/plain rendering if cached CSS is stale */
+        .btn-link-primary{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 14px;border-radius:10px;color:#fff;text-decoration:none;font-weight:700;background:#2563eb;box-shadow:0 8px 20px rgba(37,99,235,.35)}
+        .btn-link-primary:hover{background:#1d4ed8}
+        .w-12{width:48px}.h-12{height:48px}.rounded-full{border-radius:9999px}.w-5{width:20px}.h-5{height:20px}
+        .mtr-logo-large{width:110px;height:110px;border-radius:9999px;object-fit:cover}
+    </style>
+
 </head>
 <body>
     <!-- Header -->
@@ -95,7 +106,7 @@
         <div class="container">
             <div class="header-content">
                 <div class="logo">
-                    <span class="logo-icon">🥊</span>
+                    <img src="https://pink-blank-vicuna-260.mypinata.cloud/ipfs/bafybeiah2fffgw6y6aomfx5b5pgav7wedo3qdtqxqteg2glvmgzs6fpivu" alt="MTR Logo" class="logo-icon w-12 h-12 rounded-full" onerror="this.style.display='none'">
                     <span class="logo-text">MusicToken Ring</span>
                 </div>
                 <h2 class="slogan">Music Token Ring – The Wall Street of Beats</h2>
@@ -103,7 +114,8 @@
                 <div class="header-badges">
                     <span class="badge">🎵 Deezer</span>
                     <span class="badge badge-live">🔴 Live</span>
-                    <span class="badge" id="balanceDisplay">Tu MTR: --</span>
+                    <span class="badge" id="onchainBalanceDisplay">On-chain: --</span>
+                    <span class="badge" id="appBalanceDisplay">Jugable: --</span>
                 </div>
 
                 <div class="wallet-section">
@@ -112,6 +124,9 @@
                     </button>
                     <span id="walletAddress" class="wallet-address hidden"></span>
                 </div>
+                <p id="walletNetworkWarning" class="wallet-network-warning hidden">
+                    ⚠️ Red incorrecta. Cambia a Base (8453) para jugar y verificar depósitos.
+                </p>
                 
                 <!-- AUTH BUTTON -->
                 <div id="authButton">
@@ -236,20 +251,25 @@
                     <div class="settlement-card">
                         <h4>Comprar MTR directo</h4>
                         <p class="settlement-help">
-                            Compra MTR en Aerodrome y vuelve aquí: el saldo se actualiza automáticamente al conectar tu wallet en Base.
+                            Compra MTR en Aerodrome y vuelve aquí. El saldo jugable solo se habilita tras verificación on-chain/backend del hash en Base.
                         </p>
                         <div class="settlement-grid">
-                            <a class="btn-primary" target="_blank" rel="noopener noreferrer" href="https://aerodrome.finance/swap?from=ETH&to=0x99cd1eb32846c9027ed9cb8710066fa08791c33b">Comprar MTR en Aerodrome</a>
- codex/migrate-mtoken-to-mtr-on-base-chain-cp11cg
-                            <p class="settlement-help">Contrato oficial MTR en Base (checksum validado).</p>
-                            <a class="btn-secondary" target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">🔎 Ver token MTR y supply en Basescan</a>
-
- codex/migrate-mtoken-to-mtr-on-base-chain-9f5qe8
-                            <p class="settlement-help">Contrato MTR: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
-
-                            <p class="settlement-help">Contrato MTR: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
- feature/wall-street-v2
- feature/wall-street-v2
+                            <a class="btn-primary btn-link-primary bg-blue-600 hover:bg-blue-700 shadow" target="_blank" rel="noopener noreferrer" href="https://aerodrome.finance/swap?from=ETH&to=0x99cd1eb32846c9027ed9cb88710066fa08791c33b">
+                                <svg class="link-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                                Jugar Ahora
+                            </a>
+                            <a class="btn-primary btn-link-primary bg-blue-600 hover:bg-blue-700 shadow" target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb88710066fa08791c33b">
+                                <svg class="link-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                                Ver Contrato en Basescan
+                            </a>
+                            <a class="btn-primary btn-link-primary bg-blue-600 hover:bg-blue-700 shadow" target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb88710066fa08791c33b">
+                                <svg class="link-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                                Ver Supply 99.99M MTR
+                            </a>
+                            <p class="settlement-help">Contrato MTR: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb88710066fa08791c33b">0x99cd1eb32846c9027ed9cb88710066fa08791c33b</a></p>
+                            <p class="settlement-help" id="tokenConfigError" style="color:#ff6b6b;display:none;"></p>
+                            <input id="depositTxHash" class="payment-input" type="text" placeholder="Pega hash de compra en Base (0x...)" autocomplete="off">
+                            <button type="button" class="btn-secondary" id="creditPurchaseBtn" onclick="verifyPurchasedMtrTx()">🔎 Verificar depósito</button>
                         </div>
                         
                     </div>
@@ -271,24 +291,11 @@
 
             <section class="payments-showcase">
                 <p class="streaming-label">Sobre MTR</p>
-                <div class="settlement-card">
+                <div class="settlement-card about-mtr-card">
+                    <img src="https://pink-blank-vicuna-260.mypinata.cloud/ipfs/bafybeiah2fffgw6y6aomfx5b5pgav7wedo3qdtqxqteg2glvmgzs6fpivu" alt="MTR Logo" class="mtr-logo-large" onerror="this.style.display='none'">
                     <p>Token ERC-20 en Base. Liquidez lockeada en Aerodrome.</p>
-                    <p>Contrato: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b.</p>
- codex/migrate-mtoken-to-mtr-on-base-chain-cp11cg
-                    <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR.</p>
-                    <div class="settlement-grid">
-                        <a class="btn-primary" target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">📈 Ver token MTR en Basescan</a>
-                        <p class="settlement-help">Este botón abre el explorer del token para ver supply, holders y transacciones.</p>
-                    </div>
-
- codex/migrate-mtoken-to-mtr-on-base-chain-9f5qe8
-                    <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR (<a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">ver en Basescan</a>)</p>
-                    <p>Explorer: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">https://basescan.org/token/0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
-
-                    <p>Contrato verificado: 0x99cd1eb32846c9027ed9cb8710066fa08791c33b —Supply total: 99,990,000 MTR (<a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">ver en Basescan</a>)</p>
-                    <p>Explorer: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b">https://basescan.org/address/0x99cd1eb32846c9027ed9cb8710066fa08791c33b</a></p>
- feature/wall-street-v2
- feature/wall-street-v2
+                    <p>Contrato verificado: <a target="_blank" rel="noopener noreferrer" href="https://basescan.org/address/0x99cd1eb32846c9027ed9cb88710066fa08791c33b">0x99cd1eb32846c9027ed9cb88710066fa08791c33b</a></p>
+                    <p>Supply total: 99,990,000 MTR (99.99M).</p>
                 </div>
             </section>
 
@@ -400,7 +407,8 @@
                         <div class="bet-section">
                             <h3>💰 Tu Apuesta</h3>
                             <div class="bet-info">
-                                <span><span id="balanceLabel">Tu MTR</span>: <strong id="userBalance">0</strong> MTR</span>
+                                <span><span id="balanceLabel">Tu MTR (on-chain)</span>: <strong id="onchainMtrBalance">--</strong> MTR</span>
+                                <span>Saldo jugable: <strong id="userBalance">0</strong> MTR</span>
                                 <span>Mínimo: <strong id="minBet">100</strong> MTR</span>
                             </div>
                             <input 
@@ -689,184 +697,17 @@
     </footer>
 
     <!-- Scripts -->
-    <script src="./auth-system.js"></script>
-    <script src="./game-engine.js"></script>
+    <script src="./auth-system.js?v=20260228mtr2"></script>
+    <script src="./game-engine.js?v=20260228mtr2"></script>
     <script>window.MTR_INLINE_TOP_STREAMS_ACTIVE = true;</script>
-    <script src="./app.js?v=20260227mtr"></script>
-    <script src="./top-streams-fallback.js?v=20260227mtr"></script>
-
-
-
-
+    <script src="./app.js?v=20260228mtr2"></script>
+    <script src="./top-streams-fallback.js?v=20260228mtr2"></script>
 
 
     <script>
-
-
-        // Dashboard inline fallback removed; using top-streams-fallback.js
-
-
-        (function () {
-            var dashboardRegion = 'latam';
-            var dashboardOffset = 0;
-
-            function getDashboardList() {
-                return document.getElementById('streamDashboardTrackList');
-            }
-
-            function tracksByRegion(region) {
-                var data = {
-                    latam: [
-                        { title: 'Luna', artist: 'Feid', cover: 'https://e-cdns-images.dzcdn.net/images/cover/9f4c9025e2f4f4be85a8d0f95f3bc5fe/250x250-000000-80-0-0.jpg', stat: '• 18.4% del top' },
-                        { title: 'Si Antes Te Hubiera Conocido', artist: 'KAROL G', cover: 'https://e-cdns-images.dzcdn.net/images/cover/4aa4b9f4674f7f9f7428962456f31cc7/250x250-000000-80-0-0.jpg', stat: '• 15.9% del top' },
-                        { title: 'Perro Negro', artist: 'Bad Bunny', cover: 'https://e-cdns-images.dzcdn.net/images/cover/236f9df9f6f95cc8c6f0707dbe6839df/250x250-000000-80-0-0.jpg', stat: '• 14.8% del top' },
-                        { title: 'La Falda', artist: 'Myke Towers', cover: 'https://e-cdns-images.dzcdn.net/images/cover/3aebce9e3ec736beee8da30258aab6fa/250x250-000000-80-0-0.jpg', stat: '• 12.9% del top' },
-                        { title: 'Gata Only', artist: 'FloyyMenor', cover: 'https://e-cdns-images.dzcdn.net/images/cover/83d2abea3f2826f384749fd84d836c8e/250x250-000000-80-0-0.jpg', stat: '• 11.3% del top' },
-                        { title: 'Puntería', artist: 'Shakira', cover: 'https://e-cdns-images.dzcdn.net/images/cover/3f1582203c1667b663219c2f47825550/250x250-000000-80-0-0.jpg', stat: '• 10.2% del top' },
-                        { title: 'QLO', artist: 'Young Miko', cover: 'https://e-cdns-images.dzcdn.net/images/cover/f15d8bc1ecf71ac95f640117f4d5e585/250x250-000000-80-0-0.jpg', stat: '• 8.7% del top' },
-                        { title: 'Adivino', artist: 'Bad Bunny', cover: 'https://e-cdns-images.dzcdn.net/images/cover/e1d6d6c45f7ec902f9b2e8db0f9d377f/250x250-000000-80-0-0.jpg', stat: '• 7.8% del top' }
-                    ],
-                    us: [
-                        { title: 'Espresso', artist: 'Sabrina Carpenter', cover: 'https://e-cdns-images.dzcdn.net/images/cover/94bfaf6f3b278ba8e56ef8fca0ca65a4/250x250-000000-80-0-0.jpg', stat: '• 17.8% del top' },
-                        { title: 'Lose Control', artist: 'Teddy Swims', cover: 'https://e-cdns-images.dzcdn.net/images/cover/c025cd9e3f0980d7f33173f66c66fdfd/250x250-000000-80-0-0.jpg', stat: '• 15.9% del top' },
-                        { title: 'Beautiful Things', artist: 'Benson Boone', cover: 'https://e-cdns-images.dzcdn.net/images/cover/4ff4d2e2e89ae5fd3df5e6eabf78f8f6/250x250-000000-80-0-0.jpg', stat: '• 14.4% del top' },
-                        { title: 'Too Sweet', artist: 'Hozier', cover: 'https://e-cdns-images.dzcdn.net/images/cover/7100802cbf6de021bf33f6f502838177/250x250-000000-80-0-0.jpg', stat: '• 13.2% del top' },
-                        { title: 'Fortnight', artist: 'Taylor Swift', cover: 'https://e-cdns-images.dzcdn.net/images/cover/46dc36370b32276115be5f66f8f70855/250x250-000000-80-0-0.jpg', stat: '• 11.6% del top' },
-                        { title: 'I Had Some Help', artist: 'Post Malone', cover: 'https://e-cdns-images.dzcdn.net/images/cover/2b9d74ac9e3b4fe26c7c0e59101cf15f/250x250-000000-80-0-0.jpg', stat: '• 10.1% del top' },
-                        { title: 'Birds of a Feather', artist: 'Billie Eilish', cover: 'https://e-cdns-images.dzcdn.net/images/cover/221551f4f4d74f6d20f4f2af2cfcbf60/250x250-000000-80-0-0.jpg', stat: '• 9.0% del top' },
-                        { title: 'Please Please Please', artist: 'Sabrina Carpenter', cover: 'https://e-cdns-images.dzcdn.net/images/cover/0e3f4d3ac048f6a8b6b91f44389f6515/250x250-000000-80-0-0.jpg', stat: '• 8.0% del top' }
-                    ],
-                    eu: [
-                        { title: "Stumblin' In", artist: 'Cyril', cover: 'https://e-cdns-images.dzcdn.net/images/cover/3f4b8cf4be2f16ebf3d6f8cfad8aa7c1/250x250-000000-80-0-0.jpg', stat: '• 18.2% del top' },
-                        { title: 'Mwaki', artist: 'Zerb', cover: 'https://e-cdns-images.dzcdn.net/images/cover/cc8f20c021f39d8444ec4f7f6d1d6e57/250x250-000000-80-0-0.jpg', stat: '• 16.5% del top' },
-                        { title: 'Texas Hold Em', artist: 'Beyonce', cover: 'https://e-cdns-images.dzcdn.net/images/cover/c5dfcb2f5a13f5327dd58476fdd0f9ed/250x250-000000-80-0-0.jpg', stat: '• 14.6% del top' },
-                        { title: 'Pedro', artist: 'Jaxomy', cover: 'https://e-cdns-images.dzcdn.net/images/cover/7fe2fcc56bcf8b188ad1a2b8ad34ec08/250x250-000000-80-0-0.jpg', stat: '• 12.9% del top' },
-                        { title: 'We Pray', artist: 'Coldplay', cover: 'https://e-cdns-images.dzcdn.net/images/cover/88fbf030f40bb08f61aa11d77ec2a3f8/250x250-000000-80-0-0.jpg', stat: '• 11.0% del top' },
-                        { title: 'MILLION DOLLAR BABY', artist: 'Tommy Richman', cover: 'https://e-cdns-images.dzcdn.net/images/cover/53ef5b98c4f886d86fbf2deb4228bb0e/250x250-000000-80-0-0.jpg', stat: '• 9.8% del top' },
-                        { title: 'A Bar Song', artist: 'Shaboozey', cover: 'https://e-cdns-images.dzcdn.net/images/cover/18b0fef52ac2957e574c5f7a357f6ce2/250x250-000000-80-0-0.jpg', stat: '• 8.8% del top' },
-                        { title: 'Good Luck, Babe!', artist: 'Chappell Roan', cover: 'https://e-cdns-images.dzcdn.net/images/cover/d095db4ad8d9f6407781c38b3dd9df04/250x250-000000-80-0-0.jpg', stat: '• 8.2% del top' }
-                    ]
-                };
-                return data[region] || data.latam;
-            }
-
-            function clean(value) {
-                var text = String(value || '');
-                text = text.replace(/codex\/[^\s]+/gi, '').replace(/feature\/[^\s]+/gi, '').replace(/cargando\.{0,3}/gi, '').trim();
-                return text;
-            }
-
-            function purgeInjectedArtifacts() {
-                var list = getDashboardList();
-                if (!list) return;
-                var targets = list.querySelectorAll('.stream-card-info strong, .stream-card-info span');
-                for (var i = 0; i < targets.length; i++) {
-                    var node = targets[i];
-                    var cleaned = clean(node.textContent || '');
-                    if (!cleaned && node.matches('span.stream-delta')) cleaned = '• N/D';
-                    if (!cleaned && node.matches('span:not(.stream-delta)')) cleaned = 'Artista';
-                    if (!cleaned && node.matches('strong')) cleaned = 'Sin título';
-                    node.textContent = cleaned;
-                }
-            }
-
-            function protectDashboardFromInjectedText() {
-                var list = getDashboardList();
-                if (!list || list.dataset.protected === '1') return;
-                list.dataset.protected = '1';
-                var observer = new MutationObserver(function () {
-                    purgeInjectedArtifacts();
-                });
-                observer.observe(list, { childList: true, subtree: true, characterData: true });
-            }
-
-            function sanitizeDashboardCards() {
-                var list = getDashboardList();
-                if (!list) return;
-                var cards = list.querySelectorAll('.stream-card');
-                for (var i = 0; i < cards.length; i++) {
-                    var info = cards[i].querySelector('.stream-card-info');
-                    if (!info) continue;
-                    var strong = info.querySelector('strong');
-                    var spans = info.querySelectorAll('span');
-                    if (!strong || spans.length < 2) continue;
-
-                    var artist = spans[0];
-                    var stat = spans[1];
-
-                    strong.textContent = clean(strong.textContent || 'Sin título') || 'Sin título';
-                    artist.textContent = clean(artist.textContent || 'Artista') || 'Artista';
-                    stat.textContent = clean(stat.textContent || '• N/D') || '• N/D';
-
-                    while (info.childNodes.length > 3) {
-                        info.removeChild(info.lastChild);
-                    }
-
-                }
-            }
-
-            var fallbackCover = 'data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect width=%2264%22 height=%2264%22 rx=%2210%22 fill=%22%232f3542%22/%3E%3Ctext x=%2232%22 y=%2239%22 text-anchor=%22middle%22 font-size=%2226%22%3E%F0%9F%8E%B5%3C/text%3E%3C/svg%3E';
-            function render(region) {
-                var list = getDashboardList();
-                if (!list) return;
-                var tracks = tracksByRegion(region);
-                var html = '';
-                for (var i = 0; i < tracks.length; i++) {
-                    var t = tracks[i];
-                    var cover = t.cover || fallbackCover;
-                    html += '<article class="stream-card">' +
-                        '<img src="' + cover + '" alt="' + clean(t.title) + '">' +
-                        '<div class="stream-card-info">' +
-                        '<strong>' + clean(t.title) + '</strong>' +
-                        '<span>' + clean(t.artist) + '</span>' +
-                        '<span class="stream-delta neutral">' + clean(t.stat) + '</span>' +
-                        '</div></article>';
-                }
-                list.innerHTML = html;
-                var covers = list.querySelectorAll('img');
-                for (var j = 0; j < covers.length; j++) {
-                    covers[j].onerror = function () {
-                        this.onerror = null;
-                        this.src = fallbackCover;
-                    };
-                }
-                sanitizeDashboardCards();
-
-                window.moveDashboardCarousel(0);
-            }
-
-            window.setDashboardRegion = function (region) {
-                dashboardRegion = region || 'latam';
-                var btns = document.querySelectorAll('.stream-region-tab');
-                for (var i = 0; i < btns.length; i++) {
-                    var b = btns[i];
-                    b.classList.toggle('active', b.dataset && b.dataset.region === dashboardRegion);
-                }
-                render(dashboardRegion);
-            };
-
-            window.moveDashboardCarousel = function (direction) {
-                var list = getDashboardList();
-                if (!list) return;
-                if (typeof direction === 'number') dashboardOffset = Math.max(0, dashboardOffset + direction);
-                var step = Math.max(220, Math.floor(list.clientWidth * 0.55));
-                list.scrollTo({ left: dashboardOffset * step, behavior: 'smooth' });
-            };
-
-            document.addEventListener('DOMContentLoaded', function () {
-                render('latam');
-                sanitizeDashboardCards();
-                protectDashboardFromInjectedText();
-                purgeInjectedArtifacts();
-                setInterval(function () { sanitizeDashboardCards(); purgeInjectedArtifacts(); }, 1200);
-
-                sanitizeDashboardCards();
-                setInterval(sanitizeDashboardCards, 2000);
-
-            });
-        })();
         // Variables globales
         let selectedSong = null;
+        window.__mtrOnChainBalance = Number(window.__mtrOnChainBalance || 0);
         let currentMode = null;
 
 
@@ -898,7 +739,7 @@
                 }
 
                 const roomParam = urlParams.get('room');
-                if (roomParam) {
+                    if (roomParam) {
                     selectMode('private');
                     document.getElementById('joinRoomCode').value = roomParam.toUpperCase();
                     showToast('Sala privada detectada. Selecciona tu canción para unirte.', 'info');
@@ -979,7 +820,6 @@
                 </div>
             `;
         }
-
         // Seleccionar modo
         function selectMode(mode) {
             currentMode = mode;
@@ -1021,6 +861,9 @@
                         ⚔️ Buscar Rival
                     </button>
                 `;
+                const startQuickBtn = document.getElementById('startQuickBtn');
+                if (startQuickBtn) startQuickBtn.dataset.baseState = 'ready';
+                updateBetEligibility();
             } else if (mode === 'private') {
                 buttonsDiv.innerHTML = `
                     <button type="button" onclick="createRoom()" class="btn-primary" id="createRoomBtn" disabled>
@@ -1089,17 +932,45 @@
                     btn.disabled = false;
                 }
             });
+            updateBetEligibility();
         }
 
         // Apuesta rápida
         function quickBet(amount) {
             document.getElementById('betAmount').value = amount;
+            updateBetEligibility();
+        }
+
+
+        function updateBetEligibility() {
+            const startQuickBtn = document.getElementById('startQuickBtn');
+            const betAmountEl = document.getElementById('betAmount');
+            const onchainBalance = Number(window.__mtrOnChainBalance || 0);
+            const bet = parseFloat(betAmountEl?.value || '0');
+            if (!startQuickBtn) return;
+
+            const canCoverBet = !!bet && onchainBalance >= bet;
+            if (startQuickBtn.dataset.baseState === 'ready') {
+                startQuickBtn.disabled = !canCoverBet;
+            }
+
+            if (!canCoverBet && bet > 0) {
+                startQuickBtn.title = 'Saldo on-chain insuficiente para la apuesta';
+            } else {
+                startQuickBtn.title = '';
+            }
         }
 
         // Iniciar según modo
         async function startQuickMatch() {
             if (!selectedSong) return;
             const bet = parseInt(document.getElementById('betAmount').value) || 100;
+            const onchainBalance = Number(window.__mtrOnChainBalance || 0);
+            if (onchainBalance < bet) {
+                showToast('Saldo on-chain insuficiente para esta apuesta', 'error');
+                updateBetEligibility();
+                return;
+            }
             if (typeof GameEngine !== 'undefined') {
                 await GameEngine.joinQuickMatch(selectedSong, bet);
             } else {
@@ -1253,75 +1124,171 @@
                 showToast(`Retiro solicitado: ${payout.requestId || 'ID pendiente'}`, 'success');
             }
         }
+
+        function isBaseTxHash(value) {
+            return /^0x([A-Fa-f0-9]{64})$/.test(value || '');
+        }
+
+        async function verifyPurchasedMtrTx() {
+            const txInput = document.getElementById('depositTxHash');
+            const creditButton = document.getElementById('creditPurchaseBtn');
+            const txHash = txInput?.value?.trim();
+            if (!isBaseTxHash(txHash)) {
+                showToast('Pega un hash válido de Base (0x + 64 caracteres hex)', 'error');
+                return;
+            }
+            if (typeof GameEngine === 'undefined') {
+                showToast('GameEngine no está cargado', 'error');
+                return;
+            }
+
+            if (creditButton) creditButton.disabled = true;
+            try {
+                const result = await GameEngine.verifyDepositAndCredit(txHash, { network: 'base' });
+                if (result?.credited || typeof result?.newBalance === 'number') {
+                    showToast('Depósito verificado y acreditado. Ya puedes usar tu saldo en partidas pagadas.', 'success');
+                    if (txInput) txInput.value = '';
+                } else if (result?.status) {
+                    showToast(`Estado de verificación on-chain: ${result.status}`, 'info');
+                }
+            } finally {
+                if (creditButton) creditButton.disabled = false;
+            }
+        }
+
+        const betAmountInput = document.getElementById('betAmount');
+        if (betAmountInput) betAmountInput.addEventListener('input', updateBetEligibility);
+
         window.showIncomingChallenge = showIncomingChallenge;
+        window.verifyPurchasedMtrTx = verifyPurchasedMtrTx;
+        window.updateBetEligibility = updateBetEligibility;
     </script>
 
     <script type="module">
-        import { createConfig, http, connect, getAccount, watchAccount, reconnect, readContract } from 'https://esm.sh/@wagmi/core';
-        import { base } from 'https://esm.sh/wagmi/chains';
-        import { injected } from 'https://esm.sh/@wagmi/connectors';
-        import { walletConnect } from 'https://esm.sh/@wagmi/connectors';
-        import { formatUnits } from 'https://esm.sh/viem';
+        import { createPublicClient, createWalletClient, custom, http, formatUnits, isAddress, getAddress } from 'https://esm.sh/viem';
+        import { base } from 'https://esm.sh/viem/chains';
 
-        const MTR_TOKEN = '0x99cd1eb32846c9027ed9cb8710066fa08791c33b';
-        const ERC20_ABI = [
-            { type: 'function', name: 'balanceOf', stateMutability: 'view', inputs: [{ name: 'account', type: 'address' }], outputs: [{ name: '', type: 'uint256' }] }
-        ];
+        const EXPECTED_MTR_TOKEN = '0x99cd1eb32846c9027ed9cb88710066fa08791c33b';
+        const MTR_TOKEN = window.CONFIG?.MTR_TOKEN_ADDRESS || EXPECTED_MTR_TOKEN;
+        const publicClient = createPublicClient({ chain: base, transport: http('https://mainnet.base.org') });
 
-        const wagmiConfig = createConfig({
-            chains: [base],
-            connectors: [
-                injected({ target: 'metaMask' }),
-                walletConnect({ projectId: window.WALLETCONNECT_PROJECT_ID || 'demo-project-id' })
-            ],
-            transports: {
-                [base.id]: http('https://mainnet.base.org')
+        let connectedAddress = null;
+        let connectedChainId = null;
+
+        function setOnchainBalanceError(label = 'Error RPC') {
+            const badge = document.getElementById('onchainBalanceDisplay');
+            const onchainBalance = document.getElementById('onchainMtrBalance');
+            if (badge) badge.textContent = `On-chain: ${label}`;
+            if (onchainBalance) onchainBalance.textContent = label;
+        }
+
+        function validateMtrTokenAddress() {
+            const errorEl = document.getElementById('tokenConfigError');
+            if (!isAddress(MTR_TOKEN)) {
+                if (errorEl) {
+                    errorEl.textContent = 'Error crítico: la address MTR configurada es inválida.';
+                    errorEl.style.display = 'block';
+                }
+                return false;
             }
-        });
+            const checksummed = getAddress(MTR_TOKEN);
+            if (checksummed.toLowerCase() !== EXPECTED_MTR_TOKEN.toLowerCase()) {
+                if (errorEl) {
+                    errorEl.textContent = `Error crítico: address MTR no permitida (${checksummed}).`;
+                    errorEl.style.display = 'block';
+                }
+                return false;
+            }
+            if (errorEl) errorEl.style.display = 'none';
+            return true;
+        }
+
+        async function ensureBaseChain() {
+            if (!window.ethereum) {
+                if (typeof showToast === 'function') showToast('Instala MetaMask para usar wallet en Base', 'error');
+                return false;
+            }
+            const chainHex = await window.ethereum.request({ method: 'eth_chainId' });
+            const chainId = Number.parseInt(chainHex, 16);
+            connectedChainId = chainId;
+            if (chainId === 8453) return true;
+
+            if (typeof showToast === 'function') showToast('Cambia a Base para MTR', 'error');
+            try {
+                await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: '0x2105' }] });
+                connectedChainId = 8453;
+                return true;
+            } catch (error) {
+                console.warn('[wallet] switch to base rejected', error);
+                return false;
+            }
+        }
 
         async function refreshMtrBalance(address) {
             if (!address) return;
+            if (!validateMtrTokenAddress()) {
+                setOnchainBalanceError('Address inválida');
+                if (typeof showToast === 'function') showToast('Address MTR inválida. Contacta soporte.', 'error');
+                return;
+            }
             try {
-                console.log('[wallet] reading MTR balance', { address });
-                const balance = await readContract(wagmiConfig, {
+                const balance = await publicClient.readContract({
                     address: MTR_TOKEN,
-                    abi: ERC20_ABI,
+                    abi: [{ type: 'function', name: 'balanceOf', stateMutability: 'view', inputs: [{ name: 'account', type: 'address' }], outputs: [{ name: '', type: 'uint256' }] }],
                     functionName: 'balanceOf',
                     args: [address]
                 });
-                const formatted = Number(formatUnits(balance, 18)).toLocaleString('es-ES', { maximumFractionDigits: 4 });
-                const badge = document.getElementById('balanceDisplay');
-                const userBalance = document.getElementById('userBalance');
+                const numericBalance = Number(formatUnits(balance, 18));
+                window.__mtrOnChainBalance = numericBalance;
+                const formatted = numericBalance.toLocaleString('es-ES', { maximumFractionDigits: 4 });
+                const badge = document.getElementById('onchainBalanceDisplay');
+                const onchainBalance = document.getElementById('onchainMtrBalance');
                 if (badge) badge.textContent = `Tu MTR: ${formatted}`;
-                if (userBalance) userBalance.textContent = formatted;
-                console.log('[wallet] MTR balance updated', { formatted });
+                if (onchainBalance) onchainBalance.textContent = formatted;
+                if (typeof window.updateBetEligibility === 'function') window.updateBetEligibility();
             } catch (error) {
                 console.error('[wallet] balance read error', error);
+                setOnchainBalanceError();
+                if (typeof showToast === 'function') showToast('No se pudo leer balance on-chain (RPC/Base)', 'error');
             }
         }
 
-        function renderWallet(account) {
+        function renderWallet() {
             const walletEl = document.getElementById('walletAddress');
             const btnEl = document.getElementById('walletConnectBtn');
+            const warningEl = document.getElementById('walletNetworkWarning');
             if (!walletEl || !btnEl) return;
-            if (account?.address) {
-                walletEl.textContent = `${account.address.slice(0, 6)}...${account.address.slice(-4)}`;
+
+            if (connectedAddress) {
+                walletEl.textContent = `${connectedAddress.slice(0, 6)}...${connectedAddress.slice(-4)}`;
                 walletEl.classList.remove('hidden');
-                btnEl.textContent = 'Wallet conectada';
-                localStorage.setItem('mtr_wallet', account.address);
-                localStorage.setItem('mtr_wallet_chain', 'base');
-                refreshMtrBalance(account.address);
+                btnEl.textContent = connectedChainId === 8453 ? 'Wallet conectada' : 'Cambiar a Base';
+                if (warningEl) warningEl.classList.toggle('hidden', connectedChainId === 8453);
+                localStorage.setItem('mtr_wallet', connectedAddress);
+                localStorage.setItem('mtr_wallet_chain', String(connectedChainId || 'unknown'));
             } else {
                 walletEl.classList.add('hidden');
                 btnEl.textContent = 'Conectar Wallet';
+                if (warningEl) warningEl.classList.add('hidden');
+                window.__mtrOnChainBalance = 0;
+                setOnchainBalanceError('Wallet no conectada');
             }
         }
 
-        async function connectWalletWagmi() {
+        async function connectWallet() {
+            if (!window.ethereum) {
+                if (typeof showToast === 'function') showToast('MetaMask no está disponible', 'error');
+                return;
+            }
             try {
-                console.log('[wallet] connect requested via wagmi');
-                await connect(wagmiConfig, { connector: injected({ target: 'metaMask' }) });
-                renderWallet(getAccount(wagmiConfig));
+                const walletClient = createWalletClient({ chain: base, transport: custom(window.ethereum) });
+                const [address] = await walletClient.requestAddresses();
+                connectedAddress = address || null;
+                const onBase = await ensureBaseChain();
+                renderWallet();
+                if (connectedAddress && onBase) {
+                    await refreshMtrBalance(connectedAddress);
+                }
             } catch (error) {
                 console.error('[wallet] connect error', error);
                 if (typeof showToast === 'function') showToast('No se pudo conectar la wallet', 'error');
@@ -1329,16 +1296,39 @@
         }
 
         const btn = document.getElementById('walletConnectBtn');
-        if (btn) btn.addEventListener('click', connectWalletWagmi);
+        if (btn) btn.addEventListener('click', connectWallet);
 
-        watchAccount(wagmiConfig, {
-            onChange(account) {
-                renderWallet(account);
+        if (window.ethereum?.on) {
+            window.ethereum.on('accountsChanged', async (accounts) => {
+                connectedAddress = accounts?.[0] || null;
+                const onBase = connectedAddress ? await ensureBaseChain() : false;
+                renderWallet();
+                if (connectedAddress && onBase) await refreshMtrBalance(connectedAddress);
+            });
+            window.ethereum.on('chainChanged', async (chainHex) => {
+                connectedChainId = Number.parseInt(chainHex, 16);
+                if (connectedChainId !== 8453 && typeof showToast === 'function') {
+                    showToast('Cambia a Base para MTR', 'error');
+                }
+                renderWallet();
+                if (connectedAddress && connectedChainId === 8453) await refreshMtrBalance(connectedAddress);
+            });
+        }
+
+        validateMtrTokenAddress();
+        if (window.ethereum) {
+            const accounts = await window.ethereum.request({ method: 'eth_accounts' });
+            connectedAddress = accounts?.[0] || null;
+            if (connectedAddress) {
+                await ensureBaseChain();
+                renderWallet();
+                if (connectedChainId === 8453) await refreshMtrBalance(connectedAddress);
+            } else {
+                renderWallet();
             }
-        });
-
-        await reconnect(wagmiConfig);
-        renderWallet(getAccount(wagmiConfig));
+        } else {
+            renderWallet();
+        }
     </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "description": "Static frontend for MusicToken Ring",
   "scripts": {
-    "build": "echo 'Static site: no build required'",
+    "build": "npm run check",
     "preview": "npx serve .",
-    "check": "node --check app.js && node --check top-streams-fallback.js && node --check src/app.js && node --check src/top-streams-fallback.js && node scripts/verify-runtime-integrity.js"
+    "check": "node --check app.js && node --check top-streams-fallback.js && node --check src/app.js && node --check src/top-streams-fallback.js && node scripts/verify-runtime-integrity.js",
+    "prepush:guard": "bash scripts/prepush-guard.sh",
+    "pr:clean": "bash scripts/create-clean-pr.sh --base main --strategy ours"
   }
 }

--- a/scripts/create-clean-pr.sh
+++ b/scripts/create-clean-pr.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Creates a clean replacement PR branch from an existing PR branch, auto-resolving
+# merge conflicts with a deterministic strategy and running pre-push guards.
+#
+# Example:
+#   scripts/create-clean-pr.sh --target codex/fix-x --base main --strategy ours
+#
+# Optional:
+#   --title "..." --body "..."  (if gh exists, creates PR automatically)
+
+TARGET_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+BASE_BRANCH="main"
+REMOTE="origin"
+STRATEGY="ours"
+TITLE=""
+BODY=""
+NO_PR=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGET_BRANCH="${2:-}"; shift 2 ;;
+    --base) BASE_BRANCH="${2:-main}"; shift 2 ;;
+    --remote) REMOTE="${2:-origin}"; shift 2 ;;
+    --strategy) STRATEGY="${2:-ours}"; shift 2 ;;
+    --title) TITLE="${2:-}"; shift 2 ;;
+    --body) BODY="${2:-}"; shift 2 ;;
+    --no-pr) NO_PR=1; shift ;;
+    *) echo "[error] Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "[error] Not inside a git repository" >&2
+  exit 1
+fi
+
+if ! git remote | grep -qx "$REMOTE"; then
+  echo "[error] Remote '$REMOTE' is not configured" >&2
+  exit 2
+fi
+
+SAFE_TARGET="$(echo "$TARGET_BRANCH" | tr '/#' '--')"
+NEW_BRANCH="clean-${SAFE_TARGET}-$(date +%Y%m%d-%H%M%S)"
+
+echo "[info] target=$TARGET_BRANCH base=$BASE_BRANCH remote=$REMOTE strategy=$STRATEGY"
+echo "[info] creating replacement branch: $NEW_BRANCH"
+
+git fetch "$REMOTE" --prune
+
+if git show-ref --verify --quiet "refs/remotes/${REMOTE}/${TARGET_BRANCH}"; then
+  git switch -C "$NEW_BRANCH" --track "${REMOTE}/${TARGET_BRANCH}"
+else
+  git switch -C "$NEW_BRANCH" "$TARGET_BRANCH"
+fi
+
+bash scripts/resolve-pr-conflicts-v2.sh \
+  --target "$NEW_BRANCH" \
+  --base "$BASE_BRANCH" \
+  --remote "$REMOTE" \
+  --strategy "$STRATEGY" \
+  --no-push
+
+npm run prepush:guard
+
+git push -u "$REMOTE" "$NEW_BRANCH"
+
+if [[ "$NO_PR" -eq 1 ]]; then
+  echo "[ok] Branch pushed: $NEW_BRANCH (PR creation skipped by --no-pr)"
+  exit 0
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  PR_TITLE="${TITLE:-Replace blocked PR: clean auto-resolved branch}"
+  PR_BODY="${BODY:-Esta PR reemplaza la anterior para evitar resolución manual de conflictos.\n\nSe creó una rama limpia, se resolvieron conflictos automáticamente con estrategia ${STRATEGY}, se ejecutó prepush:guard y luego se hizo push.}"
+  gh pr create --base "$BASE_BRANCH" --head "$NEW_BRANCH" --title "$PR_TITLE" --body "$PR_BODY"
+  echo "[ok] PR created from $NEW_BRANCH"
+else
+  echo "[warn] gh not found; open PR manually from branch $NEW_BRANCH"
+fi

--- a/scripts/prepush-guard.sh
+++ b/scripts/prepush-guard.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+FILES=(
+  "index.html"
+  "styles/main.css"
+  "game-engine.js"
+  "SAFE_ROLLOUT_CHECKLIST.md"
+  "backend/prize-service.js"
+  "config/config.js"
+)
+
+echo "[guard] Checking conflict markers in critical files..."
+if rg -n '^(<<<<<<<|=======|>>>>>>>)' "${FILES[@]}" >/dev/null 2>&1; then
+  echo "[guard][error] Conflict markers detected in critical files." >&2
+  rg -n '^(<<<<<<<|=======|>>>>>>>)' "${FILES[@]}" || true
+  exit 1
+fi
+
+echo "[guard] Conflict-marker check: OK"
+
+echo "[guard] Running project checks..."
+npm run check
+
+echo "[guard] All checks passed. Safe to push."

--- a/scripts/verify-runtime-integrity.js
+++ b/scripts/verify-runtime-integrity.js
@@ -14,6 +14,8 @@ const blockedPatterns = [
   /codex\/find-reason/gi,
   /feature\/wall-street-v2/gi,
   /codex\/fix-unexpected-token-for-error/gi,
+  /codex\/[a-z0-9._#\/-]+/gi,
+  /refs\/heads\//gi,
   /^(<<<<<<<|=======|>>>>>>>)/gm
 ];
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -66,6 +66,13 @@ body {
     font-size: 32px;
 }
 
+.w-12 { width: 48px; }
+.h-12 { height: 48px; }
+.rounded-full { border-radius: 9999px; }
+.w-5 { width: 20px; }
+.h-5 { height: 20px; }
+.shadow { box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35); }
+
 .logo-text {
     font-size: 24px;
     font-weight: 800;
@@ -541,6 +548,43 @@ body {
     margin: 0;
     color: var(--text-secondary);
     font-size: 12px;
+}
+
+
+.btn-link-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 700;
+    box-shadow: 0 8px 20px rgba(37, 99, 235, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bg-blue-600 { background: #2563eb; }
+.bg-blue-600:hover,
+.hover\:bg-blue-700:hover {
+    background: #1d4ed8;
+    transform: translateY(-1px);
+    box-shadow: 0 10px 22px rgba(29, 78, 216, 0.42);
+}
+
+.about-mtr-card {
+    align-items: center;
+    text-align: center;
+}
+
+.mtr-logo-large {
+    width: 110px;
+    height: 110px;
+    border-radius: 9999px;
+    object-fit: cover;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
 }
 .feature-item {
     background: var(--bg-secondary);
@@ -1188,6 +1232,19 @@ body {
 
 .btn-secondary:hover {
     border-color: var(--accent-green);
+}
+
+
+.btn-secondary:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+}
+
+.wallet-network-warning {
+    margin: 8px 0 0;
+    color: #ff6b6b;
+    font-size: 12px;
+    font-weight: 600;
 }
 
 .settlement-grid .btn-primary,

--- a/vercel.json
+++ b/vercel.json
@@ -24,5 +24,6 @@
       "source": "/((?!.*\\.).*)",
       "destination": "/index.html"
     }
-  ]
+  ],
+  "buildCommand": "npm run build"
 }


### PR DESCRIPTION
### Motivation
- Enable a safe, verifiable flow for users to paste a Base tx hash and have the backend/app verify and credit purchased MTR for play.
- Harden runtime/config around the MTR token address and wallet/Base integration to avoid misconfiguration or accidental play on the wrong chain.
- Add developer tooling and guards to prevent merging broken or artifact-injected content and to provide a safe rollout checklist.

### Description
- Added `SAFE_ROLLOUT_CHECKLIST.md` describing manual and automated checks for the `Verificar depósito` flow.  
- UI and UX changes in `index.html` and `styles/main.css`: added deposit input (`#depositTxHash`), verify button (`#creditPurchaseBtn`), new on-chain and app balance badges (`#onchainBalanceDisplay`, `#appBalanceDisplay`), wallet network warning, token/contract links and a refreshed header/logo, cache-busting query params and updated build id and favicon.  
- Implemented client-side verification flow and bet eligibility: added `verifyPurchasedMtrTx()`, `isBaseTxHash()`, `updateBetEligibility()` and wiring to `GameEngine.verifyDepositAndCredit(...)`, plus restrictions that quick-match requires sufficient on-chain balance.  
- Replaced parts of the legacy wallet integration with a lightweight `viem`-based client in the page module to read ERC-20 balance on Base, validate the configured MTR token address, enforce/switch to chain 8453 (Base), and handle wallet events; updated display and refresh behavior for on-chain balances.  
- Config and backend changes: moved MTR token address to environment-driven defaults (`process.env.MTR_TOKEN_ADDRESS`) in `backend/prize-service.js` and updated `config/config.js` to the new address constant.  
- Game engine adjustments: renamed balance DOM id to `appBalanceDisplay`, updated displayed labels, show a short success toast when prize tx is returned, and display tx hash text in the victory screen.  
- Project tooling and safety scripts: added `scripts/create-clean-pr.sh`, `scripts/prepush-guard.sh`, updated `scripts/verify-runtime-integrity.js` to block injected/codex artifacts, added `SAFE_ROLLOUT_CHECKLIST.md` and updated `package.json` scripts (`check`, `prepush:guard`, `pr:clean`) and `vercel.json` to include a `buildCommand`.  

### Testing
- Ran `npm run check` which executes `node --check` across the frontend scripts and `scripts/verify-runtime-integrity.js`; this completed successfully.  
- Executed `scripts/verify-runtime-integrity.js` to ensure only one `app.js` and `top-streams-fallback.js` script ref exists and to detect blocked patterns; the script passed.  
- Ran `scripts/prepush-guard.sh` (conflict marker scan + `npm run check`) locally as part of the guard flow and it completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a259b078cc832d9331ae49183e8b1a)