### PR TITLE
Agregar capa de operaciones nativas de IA en Google Cloud (hackathon)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ build
 .env.local
 .env.*.local
 vercel.env
+
+# Agentes Python (GCP AI-native ops)
+__pycache__/
+*.pyc
+.venv/
+*.jsonl

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,111 @@
+# Architecture — MTR + GCP AI-Native Ops Layer
+
+## Principle
+
+**Wrap, don't rewrite.** Vercel (frontend), Supabase (DB of record), Render
+(Node backend, `server-auto.js`), and NOWPayments (payment rail) keep doing
+exactly what they do today. Google Cloud adds a new layer of autonomous
+operations on top, talking to the existing stack only over REST / already
+proven server-to-server auth patterns (`requireInternalSecret`).
+
+```mermaid
+flowchart LR
+    subgraph Existing["Existing stack (unchanged)"]
+        Vercel["Vercel\nFrontend (app.js, game-engine.js)"]
+        Render["Render\nbackend/server-auto.js"]
+        Supabase[("Supabase\nusers, battles, deposits")]
+        NOW["NOWPayments\nwebhook + custody payouts"]
+        Base[("Base mainnet\nMTR token / vault")]
+    end
+
+    subgraph GCP["Google Cloud — AI-native ops"]
+        Scheduler["Cloud Scheduler\n(hourly)"]
+        Scout["Cloud Run\nscout_agent.py"]
+        CFO["Cloud Function\ncfo_agent.py"]
+        Host["Cloud Run\nhost_agent.py"]
+        Firestore[("Firestore\nagent state, dedupe, alerts")]
+        BQ[("BigQuery\npayments_ledger, analytics")]
+        SM["Secret Manager\nDeezer / NOWPayments keys"]
+        Vertex["Vertex AI\nGemini 2.5 Pro"]
+    end
+
+    Deezer["Deezer API"]
+
+    Scheduler -->|"POST /run"| Scout
+    Scout -->|chart data| Deezer
+    Scout -->|snapshots + detections| Firestore
+    Scout -->|invite email| ExternalMail["SMTP / A&R inbox"]
+
+    NOW -->|"webhook (signature verified)"| Render
+    Render -->|"POST /payout\n(X-Agent-Secret)"| CFO
+    CFO -->|"wallet lookup (read-only)"| Supabase
+    CFO -->|"idempotency + caps"| Firestore
+    CFO -->|ledger row, every attempt| BQ
+    CFO -->|"POST /api/internal/agent-payout\n(X-Internal-Secret)"| Render
+    Render -->|"sendPrize()\ncustody or on-chain"| NOW
+    Render -->|on-chain transfer, if not custody| Base
+
+    Vercel -->|"POST /narrate"| Host
+    Host -->|battle state, read-only| Supabase
+    Host --> Vertex
+
+    Scout -. secrets .-> SM
+    CFO -. secrets .-> SM
+```
+
+## Security rationale (read before touching payments)
+
+The repo already documents a real incident:
+`ANALISIS-VULNERABILIDAD-CONFIRMADA.md` and `RESUMEN-FUGA-FONDOS.md` describe
+a confirmed theft of 5.29 USDC from the treasury/vault wallet on 2026-03-07,
+via `/api/claim` accepting an arbitrary `walletAddress` in the request body
+without verifying it belonged to the authenticated user. That specific bug
+was fixed by looking the wallet up from `users.wallet_address` instead of
+trusting the payload.
+
+Every new money-moving path added here follows the same rule:
+
+1. **CFO agent is never public.** NOWPayments' IPN signature is verified
+   once, in `backend/server-auto.js` (`nowpayments-service.js`), which is
+   already hardened for that job. The CFO agent's `/payout` route is called
+   server-to-server with a shared secret (`CFO_AGENT_SHARED_SECRET`) — it is
+   a second stage of an already-authenticated event, not a second front door.
+2. **Wallet of record = Supabase, always.** `PaymentEvent` has no wallet
+   field. The CFO agent looks the artist's wallet up by `artist_user_id`;
+   there is no code path where a caller-supplied address reaches a payout.
+3. **The CFO agent holds no private key.** It calls
+   `POST /api/internal/agent-payout` (new route in `server-auto.js`, guarded
+   by the existing `requireInternalSecret` middleware) which reuses
+   `prize-service.js::sendPrize` — the same, already-audited signer used
+   elsewhere in the platform. One signer, one key, one audit surface.
+4. **Idempotency + caps + circuit breaker.** Every `payment_id` is processed
+   once (Firestore dedupe). Per-transaction (`CFO_PER_TX_CAP_USD`) and daily
+   (`CFO_DAILY_CAP_USD`) caps stop a bug or an attack from draining funds
+   before a human notices — the agent refuses and raises a Firestore alert
+   instead of paying past the cap.
+5. **Full audit trail.** Paid, rejected, and failed attempts all get a
+   BigQuery row, so the P&L and the security review are the same data.
+
+## Data ownership
+
+- **Supabase** stays the single source of truth for users, wallets, battles,
+  credits, deposits — nothing here duplicates or overrides that.
+- **Firestore** only holds agent-internal state: Deezer snapshots, scout
+  detections, CFO idempotency records, caps/alerts. If Firestore is wiped,
+  the platform's actual balances are unaffected (worst case: the daily cap
+  counter resets, or a duplicate detection email goes out).
+- **BigQuery** is analytics/reporting only, fed by an insert-only ledger.
+
+## Known follow-up: host-agent's Supabase key
+
+`host-agent` is deployed publicly (`--allow-unauthenticated`, since the
+Vercel frontend calls it directly from the browser flow) and currently has
+**no** Supabase credentials wired in — it runs on its deterministic fallback
+narration instead of live battle context. Do not fix this by attaching
+`SUPABASE_SERVICE_ROLE_KEY` (full write/bypass-RLS privilege) to a public
+service — that combination was specifically blocked during this build.
+Instead, create a Supabase **anon key** scoped by a read-only RLS policy on
+`battles` (score/status/artist names only, no financial columns) and set that
+as `SUPABASE_URL`/a new `SUPABASE_ANON_KEY` env var for `host-agent` only;
+`cfo-agent` and `scout-agent` keep the service-role key since they're not
+public.

--- a/DEPLOY_GCP.md
+++ b/DEPLOY_GCP.md
@@ -1,0 +1,199 @@
+# Deploying the AI-Native Ops Layer to Google Cloud
+
+Targets the [GCP Free Tier](https://cloud.google.com/free). A billing account
+still has to be linked to the project (free-tier usage isn't charged, but
+Cloud Run/Functions/Scheduler all require billing to be enabled).
+
+## Live URLs (mtr-ai-ops-2026)
+
+| Service     | URL                                                          | Access                          |
+|-------------|---------------------------------------------------------------|----------------------------------|
+| scout-agent | https://scout-agent-287417719690.us-central1.run.app          | public (read-only ops, no $)     |
+| cfo-agent   | https://cfo-agent-287417719690.us-central1.run.app             | **IAM-locked** (run.invoker only)|
+| host-agent  | https://host-agent-287417719690.us-central1.run.app            | public (no DB creds yet — see "Known follow-up" in ARCHITECTURE.md) |
+
+Cloud Scheduler `scout-hourly-scan` runs every hour on the hour (`0 * * * *`, UTC).
+
+## Status (updated during the hackathon build)
+
+Project **`mtr-ai-ops-2026`** already exists, billed on account
+`0114F6-100E75-82AE8E`, with these APIs enabled: Cloud Run, Cloud Functions,
+Cloud Scheduler, Firestore (native, `us-central1`), BigQuery
+(`mtr_analytics.payments_ledger` table created), Secret Manager (7 secrets
+created with `REPLACE_ME` placeholders — fill real values with
+`echo -n "<value>" | gcloud secrets versions add SECRET_NAME --data-file=-`),
+Vertex AI, Artifact Registry, Cloud Build.
+
+**IAM role bindings (`add-iam-policy-binding`) must be run by you directly**,
+not through this session — granting IAM/security permissions is a category
+of action this environment blocks Claude Code from executing on your behalf,
+even with prior authorization. Run the block below yourself in a terminal
+where `gcloud` is authenticated as you (it already is, from the login done
+during this session) before the deployed services will have working access
+to secrets/Firestore/BigQuery/Vertex AI:
+
+```powershell
+$PROJECT_NUMBER = gcloud projects describe mtr-ai-ops-2026 --format="value(projectNumber)"
+$sa = "serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com"
+
+foreach ($s in @("DEEZER_API_KEY","NOWPAYMENTS_API_KEY","NOWPAYMENTS_WEBHOOK_SECRET","SUPABASE_URL","SUPABASE_SERVICE_ROLE_KEY","BACKEND_INTERNAL_SECRET","CFO_AGENT_SHARED_SECRET")) {
+  gcloud secrets add-iam-policy-binding $s --member=$sa --role="roles/secretmanager.secretAccessor" --project=mtr-ai-ops-2026
+}
+gcloud projects add-iam-policy-binding mtr-ai-ops-2026 --member=$sa --role="roles/aiplatform.user"
+gcloud projects add-iam-policy-binding mtr-ai-ops-2026 --member=$sa --role="roles/datastore.user"
+gcloud projects add-iam-policy-binding mtr-ai-ops-2026 --member=$sa --role="roles/bigquery.dataEditor"
+```
+
+## 0. Prerequisites (already done for mtr-ai-ops-2026 — kept for reference / new environments)
+
+```bash
+gcloud auth login
+gcloud projects create mtr-ai-ops-2026 --name="MTR AI Ops"
+gcloud config set project mtr-ai-ops-2026
+gcloud billing projects link mtr-ai-ops-2026 --billing-account=<YOUR_BILLING_ACCOUNT_ID>
+
+gcloud services enable \
+  run.googleapis.com \
+  cloudfunctions.googleapis.com \
+  cloudscheduler.googleapis.com \
+  firestore.googleapis.com \
+  bigquery.googleapis.com \
+  secretmanager.googleapis.com \
+  aiplatform.googleapis.com \
+  artifactregistry.googleapis.com
+```
+
+## 1. Secret Manager — Deezer / NOWPayments / internal secrets
+
+```bash
+echo -n "<DEEZER_API_KEY>"          | gcloud secrets create DEEZER_API_KEY --data-file=-
+echo -n "<NOWPAYMENTS_API_KEY>"     | gcloud secrets create NOWPAYMENTS_API_KEY --data-file=-
+echo -n "<NOWPAYMENTS_WEBHOOK_SECRET>" | gcloud secrets create NOWPAYMENTS_WEBHOOK_SECRET --data-file=-
+echo -n "<SUPABASE_SERVICE_ROLE_KEY>" | gcloud secrets create SUPABASE_SERVICE_ROLE_KEY --data-file=-
+echo -n "<BACKEND_INTERNAL_SECRET>"   | gcloud secrets create BACKEND_INTERNAL_SECRET --data-file=-
+echo -n "<CFO_AGENT_SHARED_SECRET>"   | gcloud secrets create CFO_AGENT_SHARED_SECRET --data-file=-
+```
+
+Grant the Cloud Run/Functions runtime service account access:
+
+```bash
+PROJECT_NUMBER=$(gcloud projects describe mtr-ai-ops-2026 --format='value(projectNumber)')
+for SECRET in DEEZER_API_KEY NOWPAYMENTS_API_KEY NOWPAYMENTS_WEBHOOK_SECRET \
+              SUPABASE_SERVICE_ROLE_KEY BACKEND_INTERNAL_SECRET CFO_AGENT_SHARED_SECRET; do
+  gcloud secrets add-iam-policy-binding $SECRET \
+    --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+    --role="roles/secretmanager.secretAccessor"
+done
+```
+
+## 2. Firestore (native mode)
+
+```bash
+gcloud firestore databases create --location=us-central1 --type=firestore-native
+```
+
+## 3. BigQuery dataset/table for the payments ledger
+
+```bash
+bq mk --dataset --location=us-central1 mtr-ai-ops-2026:mtr_analytics
+
+bq mk --table mtr-ai-ops-2026:mtr_analytics.payments_ledger \
+  event_id:STRING,payment_id:STRING,battle_id:STRING,artist_user_id:STRING,\
+gross_usd:FLOAT,artist_split_pct:FLOAT,artist_amount_usd:FLOAT,mtr_fee_usd:FLOAT,\
+artist_wallet:STRING,status:STRING,reason:STRING,tx_ref:STRING,processed_at:TIMESTAMP
+```
+
+## 4. Scout Agent — Cloud Run + Cloud Scheduler
+
+```bash
+gcloud builds submit --tag gcr.io/mtr-ai-ops-2026/scout-agent \
+  --config <(cat <<'EOF'
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-f', 'agents/Dockerfile', '-t', 'gcr.io/mtr-ai-ops-2026/scout-agent', '.']
+images: ['gcr.io/mtr-ai-ops-2026/scout-agent']
+EOF
+) .
+
+gcloud run deploy scout-agent \
+  --image gcr.io/mtr-ai-ops-2026/scout-agent \
+  --region us-central1 \
+  --no-allow-unauthenticated \
+  --set-env-vars USE_SECRET_MANAGER=true,GCP_PROJECT_ID=mtr-ai-ops-2026,RUN_MODE=http \
+  --set-secrets DEEZER_API_KEY=DEEZER_API_KEY:latest \
+  --command gunicorn --args="--bind,0.0.0.0:8080,--chdir,agents,scout_agent:app"
+
+SCOUT_URL=$(gcloud run services describe scout-agent --region us-central1 --format='value(status.url)')
+
+gcloud scheduler jobs create http scout-hourly-scan \
+  --schedule="0 * * * *" \
+  --uri="${SCOUT_URL}/run" \
+  --http-method=POST \
+  --oidc-service-account-email="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+```
+
+## 5. CFO Agent — Cloud Function (2nd gen, HTTP)
+
+```bash
+gcloud functions deploy cfo-agent \
+  --gen2 \
+  --runtime=python311 \
+  --region=us-central1 \
+  --source=agents \
+  --entry-point=app \
+  --trigger-http \
+  --no-allow-unauthenticated \
+  --set-env-vars USE_SECRET_MANAGER=true,GCP_PROJECT_ID=mtr-ai-ops-2026,BACKEND_URL=https://musictoken-ring.onrender.com \
+  --set-secrets NOWPAYMENTS_WEBHOOK_SECRET=NOWPAYMENTS_WEBHOOK_SECRET:latest,SUPABASE_SERVICE_ROLE_KEY=SUPABASE_SERVICE_ROLE_KEY:latest,BACKEND_INTERNAL_SECRET=BACKEND_INTERNAL_SECRET:latest,CFO_AGENT_SHARED_SECRET=CFO_AGENT_SHARED_SECRET:latest
+```
+
+> `--entry-point=app` expects a WSGI `app` object — for a raw Cloud Function
+> deploy, add a one-line `main.py` in `agents/` re-exporting
+> `from cfo_agent import app` (or deploy it as a Cloud Run service exactly
+> like the scout/host agents, which is simpler and what the provided
+> `docker-compose.yml` / Dockerfile already support — recommended for the
+> hackathon demo).
+
+Then, in Render's environment variables for the existing backend, set:
+
+```
+CFO_AGENT_URL=<the deployed CFO agent URL>
+CFO_AGENT_SHARED_SECRET=<same value as the CFO_AGENT_SHARED_SECRET secret above>
+BACKEND_INTERNAL_SECRET=<same value already used by requireInternalSecret>
+```
+
+and call `integrations/gcpConnector.js::requestArtistPayout(...)` from the
+NOWPayments webhook handler in `backend/server-auto.js` once a battle-vote
+payment is confirmed.
+
+## 6. Host Agent — Cloud Run
+
+```bash
+gcloud run deploy host-agent \
+  --image gcr.io/mtr-ai-ops-2026/host-agent \
+  --region us-central1 \
+  --allow-unauthenticated \
+  --set-env-vars GCP_PROJECT_ID=mtr-ai-ops-2026,GCP_REGION=us-central1,HOST_AGENT_MODEL=gemini-2.5-pro \
+  --set-secrets SUPABASE_SERVICE_ROLE_KEY=SUPABASE_SERVICE_ROLE_KEY:latest
+```
+
+Grant the runtime service account Vertex AI access:
+
+```bash
+gcloud projects add-iam-policy-binding mtr-ai-ops-2026 \
+  --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+  --role="roles/aiplatform.user"
+```
+
+Point the Vercel frontend's battle UI at `${HOST_URL}/narrate`.
+
+## 7. Verify
+
+```bash
+curl ${SCOUT_URL}/health
+curl ${CFO_URL}/health -H "Authorization: Bearer $(gcloud auth print-identity-token)"
+curl ${HOST_URL}/health
+```
+
+Then run `bash scripts/demo.sh` for the end-to-end scenario used in the
+hackathon submission.

--- a/PITCH.md
+++ b/PITCH.md
@@ -1,0 +1,19 @@
+# PITCH — Categoría: Dinero y Acceso Financiero
+
+MusicTokenRing ya conecta a artistas independientes con fans reales de todo el
+mundo a través de batallas musicales financiadas con cripto (NOWPayments +
+token MTR en Base); lo que faltaba era operarlo sin un equipo humano detrás
+de cada paso del dinero. Con esta capa de agentes de IA nativos en Google
+Cloud, MTR se convierte en una plataforma financiera **auto-operada**: un
+agente Scout (Gemini + Vertex AI) monitorea Deezer en tiempo real y recluta
+artistas en crecimiento sin que nadie tenga que buscarlos; un agente CFO
+recibe cada pago confirmado, calcula el split 95/5 artista/plataforma, valida
+la wallet de cobro contra la base de datos —no contra lo que diga la
+solicitud entrante, la misma lección que ya aprendimos de un incidente real
+de seguridad documentado en este repo— y paga automáticamente respetando
+topes y un circuit breaker, dejando cada transacción auditada en BigQuery
+para un P&L en vivo; y un agente Host narra las batallas y anima a votar en
+tiempo real. El resultado es acceso financiero real y sin fricción para
+artistas que hoy no tienen forma de monetizar su música directamente desde
+sus fans, operado con la disciplina de un equipo financiero profesional pero
+a la velocidad y el costo de una función serverless.

--- a/agents/.env.example
+++ b/agents/.env.example
@@ -1,0 +1,46 @@
+# AI-native ops agents — local/dev config. Copy to agents/.env and fill in.
+# NEVER commit the real .env. Real deploys read these from GCP Secret Manager
+# (USE_SECRET_MANAGER=true) instead of a file — see /DEPLOY_GCP.md.
+
+# --- GCP ---
+GCP_PROJECT_ID=
+GCP_REGION=us-central1
+USE_SECRET_MANAGER=false
+FIRESTORE_DISABLED=false
+BIGQUERY_DISABLED=false
+
+# --- Supabase (read-only lookups: artist wallet of record, battle state) ---
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# --- Existing Node backend (for CFO agent payout callback) ---
+BACKEND_URL=http://localhost:3001
+BACKEND_INTERNAL_SECRET=
+
+# --- Agent-to-agent auth ---
+CFO_AGENT_SHARED_SECRET=
+
+# --- Scout agent (Deezer + email invite) ---
+SCOUT_GROWTH_THRESHOLD_PCT=20
+DEEZER_API_KEY=
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_FROM=scout-agent@musictokenring.com
+SCOUT_INVITE_INBOX=
+
+# --- CFO agent (splits + caps) ---
+CFO_ARTIST_SPLIT_PCT=95
+CFO_PER_TX_CAP_USD=200
+CFO_DAILY_CAP_USD=1000
+
+# --- Host agent (Vertex AI) ---
+HOST_AGENT_MODEL=gemini-2.5-pro
+
+# --- Connector base URLs (used by integrations/gcp_connector.py + demo.sh) ---
+SCOUT_AGENT_URL=http://localhost:8081
+CFO_AGENT_URL=http://localhost:8082
+HOST_AGENT_URL=http://localhost:8083
+
+LOG_LEVEL=INFO

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -1,0 +1,18 @@
+# Shared image for all 3 agents — the entrypoint module is selected at
+# `docker run`/Cloud Run deploy time via the AGENT_MODULE build arg or the
+# CMD override, so one image serves scout, cfo, and host.
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY agents/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY agents/ ./agents/
+COPY integrations/ ./integrations/
+
+ENV PYTHONPATH=/app/agents:/app
+ENV PORT=8080
+
+# Default: scout agent. Override CMD per-service in docker-compose.yml / Cloud Run.
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--chdir", "agents", "scout_agent:app"]

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,75 @@
+# MTR AI-Native Ops Agents
+
+Three agents that wrap the existing MusicTokenRing platform (Vercel + Render +
+Supabase + NOWPayments + on-chain MTR) with autonomous operations, built on
+Google Cloud (Vertex AI / Gemini 2.5 Pro, Cloud Run, Cloud Functions,
+Firestore, BigQuery, Secret Manager). None of them replace the existing
+frontend/backend/DB — they call into it and are called by it over REST.
+
+## 1. Scout Agent (`scout_agent.py`) — A&R IA
+
+- **Trigger:** Cloud Scheduler → `POST /run` hourly.
+- **Does:** Pulls Deezer's trending-artist chart, compares fan counts to the
+  last hourly snapshot (Firestore), flags anyone with ≥20% growth
+  (`SCOUT_GROWTH_THRESHOLD_PCT`), emails an invite to create an MTR battle,
+  and logs the detection.
+- **Never touches money.**
+- **Try it locally:**
+  ```bash
+  cd agents && FIRESTORE_DISABLED=true python scout_agent.py
+  ```
+
+## 2. CFO Agent (`cfo_agent.py`) — payments-agent
+
+- **Trigger:** `POST /payout`, called **only** by the existing Node backend
+  (`backend/server-auto.js`) after it has already verified the NOWPayments
+  webhook signature. This agent is not exposed to the public internet as a
+  payment webhook — see [ARCHITECTURE.md](../ARCHITECTURE.md#security-rationale)
+  for why.
+- **Does:** 95/5 artist/MTR split, per-tx and daily cap enforcement with a
+  circuit breaker, idempotent per `payment_id`, looks the artist's payout
+  wallet up in Supabase (never trusts the caller's payload for that), and
+  delegates the actual on-chain/custody transfer to the existing
+  `prize-service.js::sendPrize` via a new internal route
+  (`POST /api/internal/agent-payout`) instead of holding its own private key.
+  Every attempt (paid, rejected, or capped) is written to BigQuery.
+- **Why it's built this way:** see the fund-leak/vulnerability history in
+  `../ANALISIS-VULNERABILIDAD-CONFIRMADA.md` — this agent is designed to not
+  repeat that exact class of bug.
+- **Try it locally:**
+  ```bash
+  cd agents && FIRESTORE_DISABLED=true BIGQUERY_DISABLED=true CFO_AGENT_SHARED_SECRET=dev python cfo_agent.py
+  curl -X POST localhost:8082/payout -H "X-Agent-Secret: dev" -H "Content-Type: application/json" \
+    -d '{"payment_id":"demo1","artist_user_id":"<a-real-supabase-user-id>","battle_id":"b1","amount_usd":10}'
+  ```
+
+## 3. Host Agent (`host_agent.py`) — battle-host-agent
+
+- **Trigger:** `POST /narrate`, called by the Vercel frontend during an
+  active battle.
+- **Does:** Uses Vertex AI Gemini 2.5 Pro, grounded with live battle context
+  (scores, artists) read from Supabase, to narrate events, hype voting, and
+  answer fan questions. Falls back to a deterministic reply if Vertex AI
+  credentials aren't configured (so local/dev and the demo never hard-fail).
+  Never touches money or wallets.
+- **Try it locally:**
+  ```bash
+  cd agents && python host_agent.py
+  curl -X POST localhost:8083/narrate -H "Content-Type: application/json" \
+    -d '{"battle_id":"b1","event_type":"hype"}'
+  ```
+
+## Running all three together
+
+```bash
+cp agents/.env.example agents/.env   # fill in Supabase/Deezer/NOWPayments values
+docker-compose up --build
+```
+
+## Tests
+
+```bash
+python -m venv .venv && . .venv/Scripts/activate  # or source .venv/bin/activate
+pip install -r agents/requirements.txt
+pytest tests/ -q
+```

--- a/agents/cfo_agent.py
+++ b/agents/cfo_agent.py
@@ -1,0 +1,211 @@
+"""Agent 2 — CFO IA ("payments-agent").
+
+Deploy: Cloud Function (HTTP trigger), called SERVER-TO-SERVER by the existing
+Node backend (server-auto.js) *after* it has already verified the NOWPayments
+IPN signature (x-nowpayments-sig) — this agent is never exposed directly to
+NOWPayments or to the public internet as a payment webhook. That split exists
+on purpose: the Node backend already contains the hardened signature
+verification (see nowpayments-service.js); this agent focuses on the
+AI-native ops layer (split calc, ledger, P&L) and must not become a second,
+weaker front door for the same money.
+
+Safety rails (directly answering the fund-leak history in
+ANALISIS-VULNERABILIDAD-CONFIRMADA.md / RESUMEN-FUGA-FONDOS.md):
+  1. Shared-secret auth on this endpoint (CFO_AGENT_SHARED_SECRET) — only the
+     Node backend may call it.
+  2. Idempotency: each NOWPayments payment_id is processed exactly once
+     (Firestore dedupe), so a retried/duplicated webhook can't double-pay.
+  3. Wallet-of-record lookup: the artist's payout wallet is read from
+     Supabase by user_id, NEVER taken from the inbound payload. This is the
+     exact fix already applied to /api/claim, applied here too.
+  4. Per-transaction and daily caps with a circuit breaker: if either is
+     exceeded, the agent refuses to pay and raises a Firestore alert instead
+     of a silent auto-payout.
+  5. Actual on-chain payout execution is delegated back to the existing,
+     already-audited backend (prize-service.js -> sendPrize / NOWPayments
+     Custody payout) via InternalBackendClient — this agent never holds a
+     private key.
+  6. Every attempt (paid, rejected, or capped) is written to BigQuery for
+     the P&L / analytics report, whether or not the payout succeeded.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from flask import Flask, jsonify, request
+
+from common import (
+    BigQuerySink,
+    FirestoreStore,
+    InternalBackendClient,
+    SupabaseReadClient,
+    enable_local_cors,
+    env,
+    get_logger,
+)
+
+logger = get_logger("cfo_agent")
+
+ARTIST_SPLIT_PCT = float(env("CFO_ARTIST_SPLIT_PCT", default="95"))
+MTR_SPLIT_PCT = 100 - ARTIST_SPLIT_PCT
+PER_TX_CAP_USD = float(env("CFO_PER_TX_CAP_USD", default="200"))
+DAILY_CAP_USD = float(env("CFO_DAILY_CAP_USD", default="1000"))
+SHARED_SECRET = env("CFO_AGENT_SHARED_SECRET", default="")
+
+store = FirestoreStore()
+ledger = BigQuerySink(table="payments_ledger")
+supabase = SupabaseReadClient()
+backend = InternalBackendClient()
+
+app = Flask(__name__)
+enable_local_cors(app)
+
+
+@dataclass
+class PaymentEvent:
+    payment_id: str
+    artist_user_id: str
+    battle_id: str
+    amount_usd: float
+    dry_run: bool = False
+
+
+class CircuitBreakerOpen(Exception):
+    pass
+
+
+def _today_key() -> str:
+    return time.strftime("%Y-%m-%d", time.gmtime())
+
+
+def _check_and_reserve_daily_cap(amount_usd: float) -> None:
+    doc_id = _today_key()
+    day = store.get("cfo_daily_totals", doc_id) or {"total_usd": 0.0}
+    new_total = day["total_usd"] + amount_usd
+    if new_total > DAILY_CAP_USD:
+        raise CircuitBreakerOpen(
+            f"Daily cap exceeded: {day['total_usd']} + {amount_usd} > {DAILY_CAP_USD}"
+        )
+    store.set("cfo_daily_totals", doc_id, {"total_usd": new_total})
+
+
+def process_payment(event: PaymentEvent) -> dict[str, Any]:
+    """Core CFO logic: validate, split, cap-check, payout, log. Idempotent per
+    payment_id. Returns a result dict; never raises for expected rejections —
+    those are returned as {"status": "rejected", "reason": ...} and still
+    logged to BigQuery so the P&L reflects reality."""
+
+    idempotency_key = f"payment:{event.payment_id}"
+    existing = store.get("cfo_processed_payments", idempotency_key)
+    if existing:
+        logger.info("[cfo] Duplicate payment_id %s ignored (idempotent)", event.payment_id)
+        return {"status": "duplicate_ignored", "payment_id": event.payment_id}
+
+    row: dict[str, Any] = {
+        "event_id": str(uuid.uuid4()),
+        "payment_id": event.payment_id,
+        "battle_id": event.battle_id,
+        "artist_user_id": event.artist_user_id,
+        "gross_usd": event.amount_usd,
+        "processed_at": time.time(),
+    }
+
+    if event.amount_usd <= 0:
+        row.update(status="rejected", reason="non_positive_amount")
+        ledger.insert_row(row)
+        return row
+
+    if event.amount_usd > PER_TX_CAP_USD:
+        row.update(status="rejected", reason=f"exceeds_per_tx_cap({PER_TX_CAP_USD})")
+        store.add("cfo_alerts", {**row, "alert": "PER_TX_CAP_EXCEEDED"})
+        ledger.insert_row(row)
+        return row
+
+    try:
+        _check_and_reserve_daily_cap(event.amount_usd)
+    except CircuitBreakerOpen as exc:
+        row.update(status="rejected", reason=str(exc))
+        store.add("cfo_alerts", {**row, "alert": "DAILY_CAP_EXCEEDED"})
+        ledger.insert_row(row)
+        logger.warning("[cfo] Circuit breaker open: %s", exc)
+        return row
+
+    artist_wallet = supabase.get_artist_wallet(event.artist_user_id)
+    if not artist_wallet:
+        row.update(status="rejected", reason="artist_wallet_not_on_file")
+        store.add("cfo_alerts", {**row, "alert": "NO_WALLET_ON_FILE"})
+        ledger.insert_row(row)
+        return row
+
+    artist_amount = round(event.amount_usd * (ARTIST_SPLIT_PCT / 100), 6)
+    mtr_amount = round(event.amount_usd - artist_amount, 6)
+
+    row.update(
+        artist_split_pct=ARTIST_SPLIT_PCT,
+        artist_amount_usd=artist_amount,
+        mtr_fee_usd=mtr_amount,
+        artist_wallet=artist_wallet,
+    )
+
+    if event.dry_run:
+        # Verifies every guardrail (idempotency, caps, wallet-of-record
+        # lookup) without ever calling the backend's real payout route.
+        # No money moves, no BigQuery ledger row is written (nothing
+        # actually happened), and idempotency state is not recorded either
+        # so a real follow-up call with the same payment_id still goes
+        # through normally.
+        row.update(status="dry_run_ok")
+        return row
+
+    try:
+        payout_result = backend.trigger_artist_payout(
+            artist_user_id=event.artist_user_id,
+            amount_usd=artist_amount,
+            reason=f"battle:{event.battle_id}",
+            idempotency_key=idempotency_key,
+        )
+        row.update(status="paid", tx_ref=payout_result.get("txHash") or payout_result.get("id"))
+    except Exception as exc:  # noqa: BLE001
+        row.update(status="payout_failed", reason=str(exc))
+        store.add("cfo_alerts", {**row, "alert": "PAYOUT_CALL_FAILED"})
+        logger.error("[cfo] Payout call failed for %s: %s", event.payment_id, exc)
+
+    store.set("cfo_processed_payments", idempotency_key, row, merge=False)
+    ledger.insert_row(row)
+    return row
+
+
+@app.route("/health")
+def health():
+    return jsonify({"status": "ok", "agent": "cfo-agent"})
+
+
+@app.route("/payout", methods=["POST"])
+def payout_endpoint():
+    """Called by the Node backend after it has verified the NOWPayments
+    signature and confirmed the vote/payment is legitimate."""
+    if not SHARED_SECRET or request.headers.get("X-Agent-Secret") != SHARED_SECRET:
+        return jsonify({"error": "unauthorized"}), 401
+
+    body = request.get_json(force=True, silent=True) or {}
+    try:
+        event = PaymentEvent(
+            payment_id=str(body["payment_id"]),
+            artist_user_id=str(body["artist_user_id"]),
+            battle_id=str(body.get("battle_id", "")),
+            amount_usd=float(body["amount_usd"]),
+            dry_run=bool(body.get("dry_run", False)),
+        )
+    except (KeyError, ValueError, TypeError) as exc:
+        return jsonify({"error": f"invalid payload: {exc}"}), 400
+
+    result = process_payment(event)
+    status_code = 200 if result.get("status") in ("paid", "duplicate_ignored", "dry_run_ok") else 402
+    return jsonify(result), status_code
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(env("PORT", default="8082")))

--- a/agents/cloudbuild.yaml
+++ b/agents/cloudbuild.yaml
@@ -1,0 +1,4 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args: ['build', '-f', 'agents/Dockerfile', '-t', 'gcr.io/mtr-ai-ops-2026/mtr-agents', '.']
+images: ['gcr.io/mtr-ai-ops-2026/mtr-agents']

--- a/agents/common.py
+++ b/agents/common.py
@@ -1,0 +1,253 @@
+"""Shared helpers for the MTR AI-native ops agents (scout, cfo, host).
+
+Design principle: agents NEVER hold blockchain private keys and NEVER trust
+wallet addresses from an inbound request payload. Payouts are always executed
+by calling back into the existing, already-hardened Node backend
+(server-auto.js / prize-service.js), which is the only component that signs
+on-chain transactions. This mirrors the fix already applied to `/api/claim`
+in ANALISIS-VULNERABILIDAD-CONFIRMADA.md: the wallet of record always comes
+from Supabase, never from caller input.
+
+All secrets are read from environment variables (populated locally via
+docker-compose/.env, and in GCP via Secret Manager -> env at deploy time).
+Nothing here should ever hardcode a credential.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import requests
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
+
+
+def get_logger(name: str) -> logging.Logger:
+    return logging.getLogger(name)
+
+
+def enable_local_cors(app) -> None:
+    """Dev/demo convenience only: lets a static dashboard page (opened as a
+    local file or from a simple static server) call these agents directly
+    from the browser. Never used against a production origin allowlist —
+    for that, put a real gateway (e.g. Cloud Run's built-in auth or an API
+    Gateway CORS policy) in front instead of relying on this."""
+
+    @app.after_request
+    def _add_cors_headers(response):
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        response.headers["Access-Control-Allow-Headers"] = "Content-Type, X-Agent-Secret, X-Internal-Secret"
+        response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+        return response
+
+
+def env(name: str, default: Optional[str] = None, required: bool = False) -> str:
+    value = os.environ.get(name, default)
+    # Defensive: secrets piped into `gcloud secrets versions add` from
+    # PowerShell (e.g. `$v | gcloud secrets ...`) commonly pick up a
+    # trailing \r\n from the pipeline, which then breaks anything that uses
+    # the value as an HTTP header (Supabase/NOWPayments auth, etc.) with a
+    # cryptic "Invalid leading whitespace... in header value" error. Env
+    # vars/secrets have no legitimate reason to carry leading/trailing
+    # whitespace, so strip it here once instead of at every call site.
+    if value is not None:
+        value = value.strip()
+    if required and not value:
+        raise RuntimeError(f"Missing required env var: {name}")
+    return value
+
+
+# --------------------------------------------------------------------------
+# Secret Manager (GCP). Falls back to plain env vars for local dev, so the
+# same code path runs identically under `docker-compose up` and Cloud Run.
+# --------------------------------------------------------------------------
+def get_secret(secret_id: str, fallback_env: Optional[str] = None) -> Optional[str]:
+    fallback_env = fallback_env or secret_id
+    local_value = os.environ.get(fallback_env)
+    if os.environ.get("USE_SECRET_MANAGER", "false").lower() != "true":
+        return local_value
+
+    try:
+        from google.cloud import secretmanager  # type: ignore
+
+        project_id = env("GCP_PROJECT_ID", required=True)
+        client = secretmanager.SecretManagerServiceClient()
+        name = f"projects/{project_id}/secrets/{secret_id}/versions/latest"
+        response = client.access_secret_version(request={"name": name})
+        return response.payload.data.decode("UTF-8")
+    except Exception as exc:  # noqa: BLE001 - degrade gracefully in local/dev
+        get_logger("common").warning(
+            "Secret Manager lookup failed for %s (%s); falling back to env var",
+            secret_id,
+            exc,
+        )
+        return local_value
+
+
+# --------------------------------------------------------------------------
+# Firestore: agent state, dedupe/idempotency, scout detections, circuit breaker
+# --------------------------------------------------------------------------
+class FirestoreStore:
+    """Thin wrapper so agents/tests can run without a real Firestore instance
+    (USE_FIRESTORE_EMULATOR=true or FIRESTORE_DISABLED=true -> in-memory dict)."""
+
+    def __init__(self):
+        self._memory: dict[str, dict[str, Any]] = {}
+        self._client = None
+        if os.environ.get("FIRESTORE_DISABLED", "false").lower() != "true":
+            try:
+                from google.cloud import firestore  # type: ignore
+
+                self._client = firestore.Client(project=os.environ.get("GCP_PROJECT_ID"))
+            except Exception as exc:  # noqa: BLE001
+                get_logger("common").warning(
+                    "Firestore unavailable (%s); using in-memory store (local/dev only)", exc
+                )
+
+    def get(self, collection: str, doc_id: str) -> Optional[dict[str, Any]]:
+        if self._client:
+            doc = self._client.collection(collection).document(doc_id).get()
+            return doc.to_dict() if doc.exists else None
+        stored = self._memory.get(f"{collection}/{doc_id}")
+        # Return a shallow copy, never the live dict — callers (e.g. scout_agent
+        # comparing "previous" vs a just-written new snapshot) must not see
+        # their earlier read silently mutate under them via a later set().
+        return dict(stored) if stored is not None else None
+
+    def set(self, collection: str, doc_id: str, data: dict[str, Any], merge: bool = True) -> None:
+        data = {**data, "_updated_at": time.time()}
+        if self._client:
+            self._client.collection(collection).document(doc_id).set(data, merge=merge)
+            return
+        key = f"{collection}/{doc_id}"
+        if merge and key in self._memory:
+            self._memory[key] = {**self._memory[key], **data}
+        else:
+            self._memory[key] = data
+
+    def add(self, collection: str, data: dict[str, Any]) -> str:
+        doc_id = data.get("id") or str(time.time_ns())
+        self.set(collection, doc_id, data, merge=False)
+        return doc_id
+
+
+# --------------------------------------------------------------------------
+# BigQuery: revenue analytics / P&L ledger
+# --------------------------------------------------------------------------
+class BigQuerySink:
+    """Writes payment/revenue rows to BigQuery. Falls back to a local JSONL
+    file (bigquery_local.jsonl) so `docker-compose up` and tests work without
+    real GCP credentials."""
+
+    def __init__(self, dataset: str = "mtr_analytics", table: str = "payments_ledger"):
+        self.dataset = dataset
+        self.table = table
+        self._client = None
+        self._local_path = os.environ.get("BQ_LOCAL_FALLBACK_PATH", "/tmp/bigquery_local.jsonl")
+        if os.environ.get("BIGQUERY_DISABLED", "false").lower() != "true":
+            try:
+                from google.cloud import bigquery  # type: ignore
+
+                self._client = bigquery.Client(project=os.environ.get("GCP_PROJECT_ID"))
+            except Exception as exc:  # noqa: BLE001
+                get_logger("common").warning(
+                    "BigQuery unavailable (%s); writing to local fallback %s",
+                    exc,
+                    self._local_path,
+                )
+
+    def insert_row(self, row: dict[str, Any]) -> None:
+        if self._client:
+            table_ref = f"{self._client.project}.{self.dataset}.{self.table}"
+            errors = self._client.insert_rows_json(table_ref, [row])
+            if errors:
+                raise RuntimeError(f"BigQuery insert failed: {errors}")
+            return
+        with open(self._local_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, default=str) + "\n")
+
+
+# --------------------------------------------------------------------------
+# Supabase: read-only lookups (artist wallet of record, battle state).
+# Agents NEVER write balances/credits directly — that stays owned by the
+# Node backend (server-auto.js) to avoid a second source of truth for money.
+# --------------------------------------------------------------------------
+class SupabaseReadClient:
+    def __init__(self):
+        self.url = env("SUPABASE_URL", default="")
+        self.key = env("SUPABASE_SERVICE_ROLE_KEY", default="")
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "apikey": self.key,
+            "Authorization": f"Bearer {self.key}",
+            "Content-Type": "application/json",
+        }
+
+    def get_artist_wallet(self, artist_user_id: str) -> Optional[str]:
+        """Returns the wallet address on file for a user, or None. This is the
+        ONLY source of truth for "where does this artist get paid" — never the
+        webhook payload, never a request body field."""
+        if not self.url or not self.key:
+            return None
+        resp = requests.get(
+            f"{self.url}/rest/v1/users",
+            params={"id": f"eq.{artist_user_id}", "select": "id,wallet_address"},
+            headers=self._headers(),
+            timeout=10,
+        )
+        resp.raise_for_status()
+        rows = resp.json()
+        return rows[0]["wallet_address"] if rows else None
+
+    def get_active_battle(self, battle_id: str) -> Optional[dict[str, Any]]:
+        if not self.url or not self.key:
+            return None
+        resp = requests.get(
+            f"{self.url}/rest/v1/battles",
+            params={"id": f"eq.{battle_id}", "select": "*"},
+            headers=self._headers(),
+            timeout=10,
+        )
+        resp.raise_for_status()
+        rows = resp.json()
+        return rows[0] if rows else None
+
+
+@dataclass
+class InternalBackendClient:
+    """Server-to-server client for the existing Render/Node backend. Used by
+    the CFO agent to trigger the actual on-chain payout via the backend's
+    already-audited prize-service.js (sendPrize), instead of the Python agent
+    holding its own private key. Auth: BACKEND_INTERNAL_SECRET header, same
+    mechanism the existing admin routes already use."""
+
+    base_url: str = env("BACKEND_URL", default="https://musictoken-ring.onrender.com")
+    internal_secret: str = env("BACKEND_INTERNAL_SECRET", default="")
+
+    def trigger_artist_payout(
+        self, artist_user_id: str, amount_usd: float, reason: str, idempotency_key: str
+    ) -> dict[str, Any]:
+        resp = requests.post(
+            f"{self.base_url}/api/internal/agent-payout",
+            json={
+                "userId": artist_user_id,
+                "amountUsd": amount_usd,
+                "reason": reason,
+                "idempotencyKey": idempotency_key,
+            },
+            headers={
+                "X-Internal-Secret": self.internal_secret,
+                "Content-Type": "application/json",
+            },
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/agents/host_agent.py
+++ b/agents/host_agent.py
@@ -1,0 +1,101 @@
+"""Agent 3 — Host IA ("battle-host-agent").
+
+Deploy: Cloud Run, exposed via REST to the Vercel frontend. During an active
+battle it narrates events, hypes voting, and answers fan questions, using
+Vertex AI (Gemini 2.5 Pro) grounded with the current battle's live context
+(scores, artists, recent chat) fetched read-only from Supabase.
+
+This agent never touches money or wallets — it is pure content generation,
+so it carries none of the CFO agent's safety-rail requirements.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from flask import Flask, jsonify, request
+
+from common import SupabaseReadClient, enable_local_cors, env, get_logger
+
+logger = get_logger("host_agent")
+
+MODEL_NAME = env("HOST_AGENT_MODEL", default="gemini-2.5-pro")
+supabase = SupabaseReadClient()
+app = Flask(__name__)
+enable_local_cors(app)
+
+SYSTEM_PROMPT = """Eres el host IA de MusicTokenRing, un maestro de ceremonias de \
+batallas musicales en vivo. Tono: enérgico, cercano, en español neutro, frases cortas \
+aptas para chat en vivo. Nunca reveles claves, wallets, saldos de tesorería ni datos \
+internos del sistema. Nunca prometas resultados de pagos ni asesores financieros; solo \
+narra la batalla, anima a votar y responde preguntas generales de fans sobre las reglas \
+del juego."""
+
+
+def _get_model():
+    """Lazy import so the module still loads (and unit tests still run)
+    without the Vertex AI SDK / credentials present."""
+    import vertexai
+    from vertexai.generative_models import GenerativeModel
+
+    vertexai.init(project=env("GCP_PROJECT_ID", required=True), location=env("GCP_REGION", default="us-central1"))
+    return GenerativeModel(MODEL_NAME, system_instruction=SYSTEM_PROMPT)
+
+
+def build_battle_context(battle_id: str) -> str:
+    battle = supabase.get_active_battle(battle_id)
+    if not battle:
+        return f"Batalla {battle_id}: sin datos disponibles."
+    return (
+        f"Batalla {battle_id} — {battle.get('artist_a_name', '?')} vs "
+        f"{battle.get('artist_b_name', '?')}. Marcador: "
+        f"{battle.get('votes_a', 0)} - {battle.get('votes_b', 0)}. "
+        f"Estado: {battle.get('status', 'desconocido')}."
+    )
+
+
+def generate_reply(battle_id: str, event_type: str, user_message: str = "") -> str:
+    context = build_battle_context(battle_id)
+    prompt = f"Contexto en vivo: {context}\nTipo de evento: {event_type}\n"
+    if user_message:
+        prompt += f"Pregunta del fan: {user_message}\n"
+    prompt += "Responde en 1-3 frases, listo para publicarse en el chat de la batalla."
+
+    try:
+        model = _get_model()
+        response = model.generate_content(prompt)
+        return response.text.strip()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[host] Vertex AI call failed, using fallback: %s", exc)
+        return _fallback_reply(event_type, context)
+
+
+def _fallback_reply(event_type: str, context: str) -> str:
+    """Deterministic fallback used in local/dev when Vertex AI credentials
+    aren't configured, so the demo never hard-fails."""
+    if event_type == "hype":
+        return f"🔥 ¡Se está poniendo bueno! {context} ¡Voten ahora por su favorito!"
+    if event_type == "question":
+        return f"Buena pregunta. Info actual: {context}"
+    return f"Actualización: {context}"
+
+
+@app.route("/health")
+def health():
+    return jsonify({"status": "ok", "agent": "host-agent"})
+
+
+@app.route("/narrate", methods=["POST"])
+def narrate() -> Any:
+    body = request.get_json(force=True, silent=True) or {}
+    battle_id = str(body.get("battle_id", ""))
+    event_type = str(body.get("event_type", "hype"))
+    user_message = str(body.get("message", ""))
+    if not battle_id:
+        return jsonify({"error": "battle_id is required"}), 400
+
+    reply = generate_reply(battle_id, event_type, user_message)
+    return jsonify({"battle_id": battle_id, "reply": reply})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(env("PORT", default="8083")))

--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -1,0 +1,9 @@
+flask==3.0.3
+gunicorn==22.0.0
+requests==2.32.3
+google-cloud-firestore==2.16.1
+google-cloud-bigquery==3.25.0
+google-cloud-secret-manager==2.20.2
+google-cloud-aiplatform==1.60.0
+pytest==8.2.2
+pytest-mock==3.14.0

--- a/agents/scout_agent.py
+++ b/agents/scout_agent.py
@@ -1,0 +1,158 @@
+"""Agent 1 — A&R IA ("scout-agent").
+
+Every hour (via Cloud Scheduler -> HTTP -> this Cloud Run service), polls the
+Deezer API for trending artists, compares stream/fan counts against the last
+snapshot stored in Firestore, and flags artists with >=20% growth. Detections
+are logged to Firestore and an invite email is sent (SMTP, best-effort —
+failure to send never blocks the detection log).
+
+Run locally:
+    python agents/scout_agent.py            # one-off scan
+    FLASK_APP=scout_agent flask run -p 8081  # HTTP mode (Cloud Run entrypoint)
+
+Deploy: Cloud Run + Cloud Scheduler (see /DEPLOY_GCP.md).
+"""
+from __future__ import annotations
+
+import os
+import smtplib
+import time
+from email.mime.text import MIMEText
+from typing import Any, Optional
+
+import requests
+from flask import Flask, jsonify
+
+from common import FirestoreStore, enable_local_cors, get_logger, env
+
+logger = get_logger("scout_agent")
+
+DEEZER_CHART_URL = "https://api.deezer.com/chart/0/artists"
+GROWTH_THRESHOLD_PCT = float(env("SCOUT_GROWTH_THRESHOLD_PCT", default="20"))
+SNAPSHOT_COLLECTION = "scout_artist_snapshots"
+DETECTIONS_COLLECTION = "scout_detections"
+
+store = FirestoreStore()
+app = Flask(__name__)
+enable_local_cors(app)
+
+
+def fetch_trending_artists(limit: int = 50) -> list[dict[str, Any]]:
+    """Pull Deezer's trending artist chart. Public API, no key required for
+    this endpoint; DEEZER_API_KEY is reserved for endpoints that need it."""
+    resp = requests.get(DEEZER_CHART_URL, params={"limit": limit}, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("data", [])
+
+
+def compute_growth(artist: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """Compares current fan count to the last stored snapshot for this artist.
+    Returns a detection dict if growth >= GROWTH_THRESHOLD_PCT, else None."""
+    artist_id = str(artist["id"])
+    current_fans = artist.get("nb_fan", 0)
+
+    previous = store.get(SNAPSHOT_COLLECTION, artist_id)
+    store.set(
+        SNAPSHOT_COLLECTION,
+        artist_id,
+        {"artist_id": artist_id, "name": artist.get("name"), "nb_fan": current_fans, "checked_at": time.time()},
+    )
+
+    if not previous or not previous.get("nb_fan"):
+        return None  # first time we see this artist — no baseline yet
+
+    prev_fans = previous["nb_fan"]
+    if prev_fans <= 0:
+        return None
+
+    growth_pct = ((current_fans - prev_fans) / prev_fans) * 100
+    if growth_pct < GROWTH_THRESHOLD_PCT:
+        return None
+
+    return {
+        "artist_id": artist_id,
+        "name": artist.get("name"),
+        "picture": artist.get("picture_medium"),
+        "deezer_link": artist.get("link"),
+        "prev_fans": prev_fans,
+        "current_fans": current_fans,
+        "growth_pct": round(growth_pct, 2),
+        "detected_at": time.time(),
+    }
+
+
+def send_invite(detection: dict[str, Any]) -> bool:
+    """Best-effort email invite. Returns True on send, False on any failure
+    (missing SMTP config counts as a soft no-op in local/dev)."""
+    smtp_host = env("SMTP_HOST", default="")
+    invite_to = env("SCOUT_INVITE_INBOX", default="")  # A&R inbox / CRM address
+    if not smtp_host or not invite_to:
+        logger.info("[scout] SMTP not configured — logging detection only: %s", detection["name"])
+        return False
+
+    body = (
+        f"MTR Scout Agent detectó a {detection['name']} con "
+        f"+{detection['growth_pct']}% de crecimiento en fans "
+        f"({detection['prev_fans']} -> {detection['current_fans']}).\n\n"
+        f"Perfil Deezer: {detection['deezer_link']}\n"
+        f"Invitación sugerida: crear una batalla en MusicTokenRing."
+    )
+    msg = MIMEText(body)
+    msg["Subject"] = f"[MTR Scout] Artista en crecimiento: {detection['name']}"
+    msg["From"] = env("SMTP_FROM", default="scout-agent@musictokenring.com")
+    msg["To"] = invite_to
+
+    try:
+        with smtplib.SMTP(smtp_host, int(env("SMTP_PORT", default="587"))) as server:
+            server.starttls()
+            smtp_user = env("SMTP_USER", default="")
+            smtp_pass = env("SMTP_PASSWORD", default="")
+            if smtp_user:
+                server.login(smtp_user, smtp_pass)
+            server.sendmail(msg["From"], [invite_to], msg.as_string())
+        return True
+    except Exception as exc:  # noqa: BLE001 — never let a mail failure kill the scan
+        logger.warning("[scout] Email send failed: %s", exc)
+        return False
+
+
+def run_scan() -> list[dict[str, Any]]:
+    detections: list[dict[str, Any]] = []
+    try:
+        artists = fetch_trending_artists()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[scout] Deezer fetch failed: %s", exc)
+        return detections
+
+    for artist in artists:
+        detection = compute_growth(artist)
+        if not detection:
+            continue
+        emailed = send_invite(detection)
+        detection["invite_sent"] = emailed
+        store.add(DETECTIONS_COLLECTION, detection)
+        detections.append(detection)
+        logger.info("[scout] Detection logged: %s (+%s%%)", detection["name"], detection["growth_pct"])
+
+    logger.info("[scout] Scan complete: %d artists checked, %d detections", len(artists), len(detections))
+    return detections
+
+
+@app.route("/health")
+def health():
+    return jsonify({"status": "ok", "agent": "scout-agent"})
+
+
+@app.route("/run", methods=["POST", "GET"])
+def run_endpoint():
+    """Cloud Scheduler hits this hourly via an OIDC-authenticated HTTP call."""
+    detections = run_scan()
+    return jsonify({"detections": len(detections), "artists": detections})
+
+
+if __name__ == "__main__":
+    if env("RUN_MODE", default="cli") == "http":
+        app.run(host="0.0.0.0", port=int(env("PORT", default="8081")))
+    else:
+        run_scan()

--- a/backend/server-auto.js
+++ b/backend/server-auto.js
@@ -1733,6 +1733,55 @@ app.post('/api/user/add-credits', requireInternalSecret, async (req, res) => {
 });
 
 /**
+ * Agent-native ops: internal payout trigger, called ONLY by the GCP CFO
+ * agent (agents/cfo_agent.py) after it has already validated the payment,
+ * the wallet-of-record, and per-tx/daily caps. This route re-validates the
+ * wallet server-side too (defense in depth — never trust the caller's
+ * amount/user pairing blindly) and reuses sendPrize(), the same
+ * already-audited payout path used elsewhere, instead of introducing a new
+ * one. Protected by requireInternalSecret (BACKEND_INTERNAL_SECRET), same
+ * mechanism as the other /api/internal-style routes above.
+ */
+const _agentPayoutIdempotency = new Set(); // best-effort, in-process guard;
+// CFO agent already enforces the authoritative idempotency check in Firestore.
+
+app.post('/api/internal/agent-payout', requireInternalSecret, async (req, res) => {
+    try {
+        const { userId, amountUsd, reason, idempotencyKey } = req.body;
+
+        if (!userId || !amountUsd || amountUsd <= 0) {
+            return res.status(400).json({ error: 'Invalid parameters' });
+        }
+        if (idempotencyKey) {
+            if (_agentPayoutIdempotency.has(idempotencyKey)) {
+                return res.json({ success: true, duplicate: true });
+            }
+            _agentPayoutIdempotency.add(idempotencyKey);
+        }
+
+        // Wallet of record ONLY from Supabase — never trust a wallet passed in the body.
+        const { data: user, error: userError } = await supabase
+            .from('users')
+            .select('id, wallet_address')
+            .eq('id', userId)
+            .single();
+
+        if (userError || !user || !user.wallet_address) {
+            return res.status(404).json({ error: 'User or wallet not found' });
+        }
+
+        const { sendPrize } = require('./prize-service');
+        const result = await sendPrize(user.wallet_address, amountUsd);
+
+        console.log('[agent-payout]', { userId, amountUsd, reason, result });
+        res.json({ success: true, ...result });
+    } catch (error) {
+        console.error('[server] Error in agent-payout:', error);
+        res.status(500).json({ error: error.message });
+    }
+});
+
+/**
  * Vault endpoints
  */
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,71 @@
+# Local dev stack for the AI-native ops layer (scout / cfo / host agents)
+# plus the existing Node backend, wired together the same way they'll talk
+# in GCP (REST, shared secret). Does not touch Vercel/Render/Supabase —
+# Supabase is still the real DB (point SUPABASE_URL/KEY at your project or a
+# local Supabase CLI instance); this just runs the compute pieces locally.
+#
+# Usage:
+#   cp agents/.env.example agents/.env   # fill in Deezer/NOWPayments/Supabase keys
+#   docker-compose up --build
+#
+# GCP services (Firestore/BigQuery/Secret Manager/Vertex AI) are disabled by
+# default here (FIRESTORE_DISABLED / BIGQUERY_DISABLED / USE_SECRET_MANAGER)
+# so the stack runs with zero cloud credentials for local demo purposes; set
+# USE_SECRET_MANAGER=true + mount a service-account key to exercise the real
+# GCP path locally.
+version: "3.9"
+
+services:
+  backend:
+    image: node:18-alpine
+    working_dir: /app
+    command: sh -c "npm install --omit=dev && node backend/server-auto.js"
+    volumes:
+      - ./:/app
+    ports:
+      - "3001:3001"
+    env_file:
+      - .env
+    environment:
+      PORT: 3001
+      SCOUT_AGENT_URL: http://scout-agent:8080
+      CFO_AGENT_URL: http://cfo-agent:8080
+      HOST_AGENT_URL: http://host-agent:8080
+
+  scout-agent:
+    build:
+      context: .
+      dockerfile: agents/Dockerfile
+    command: ["gunicorn", "--bind", "0.0.0.0:8080", "--chdir", "agents", "scout_agent:app"]
+    ports:
+      - "8081:8080"
+    env_file:
+      - agents/.env
+    environment:
+      RUN_MODE: http
+      FIRESTORE_DISABLED: "true"
+      BIGQUERY_DISABLED: "true"
+
+  cfo-agent:
+    build:
+      context: .
+      dockerfile: agents/Dockerfile
+    command: ["gunicorn", "--bind", "0.0.0.0:8080", "--chdir", "agents", "cfo_agent:app"]
+    ports:
+      - "8082:8080"
+    env_file:
+      - agents/.env
+    environment:
+      FIRESTORE_DISABLED: "true"
+      BIGQUERY_DISABLED: "true"
+      BACKEND_URL: http://backend:3001
+
+  host-agent:
+    build:
+      context: .
+      dockerfile: agents/Dockerfile
+    command: ["gunicorn", "--bind", "0.0.0.0:8080", "--chdir", "agents", "host_agent:app"]
+    ports:
+      - "8083:8080"
+    env_file:
+      - agents/.env

--- a/integrations/gcpConnector.js
+++ b/integrations/gcpConnector.js
@@ -1,0 +1,67 @@
+/**
+ * REST connector the existing Node backend (backend/server-auto.js) uses to
+ * call the 3 GCP agents. Twin of integrations/gcp_connector.py — same
+ * endpoints/contracts, JS runtime to match the backend's actual language.
+ *
+ * Usage from server-auto.js, e.g. after the NOWPayments webhook confirms a
+ * battle-vote payment:
+ *
+ *   const { requestArtistPayout } = require('../integrations/gcpConnector');
+ *   await requestArtistPayout({ paymentId, artistUserId, battleId, amountUsd });
+ */
+
+const SCOUT_AGENT_URL = process.env.SCOUT_AGENT_URL || 'http://localhost:8081';
+const CFO_AGENT_URL = process.env.CFO_AGENT_URL || 'http://localhost:8082';
+const HOST_AGENT_URL = process.env.HOST_AGENT_URL || 'http://localhost:8083';
+const CFO_AGENT_SHARED_SECRET = process.env.CFO_AGENT_SHARED_SECRET || '';
+
+async function triggerScoutScan() {
+    const resp = await fetch(`${SCOUT_AGENT_URL}/run`, { method: 'POST' });
+    if (!resp.ok) throw new Error(`scout-agent /run failed: ${resp.status}`);
+    return resp.json();
+}
+
+async function requestArtistPayout({ paymentId, artistUserId, battleId, amountUsd }) {
+    const resp = await fetch(`${CFO_AGENT_URL}/payout`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-Agent-Secret': CFO_AGENT_SHARED_SECRET
+        },
+        body: JSON.stringify({
+            payment_id: paymentId,
+            artist_user_id: artistUserId,
+            battle_id: battleId,
+            amount_usd: amountUsd
+        })
+    });
+    return resp.json();
+}
+
+async function requestHostNarration({ battleId, eventType = 'hype', message = '' }) {
+    const resp = await fetch(`${HOST_AGENT_URL}/narrate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ battle_id: battleId, event_type: eventType, message })
+    });
+    if (!resp.ok) throw new Error(`host-agent /narrate failed: ${resp.status}`);
+    return resp.json();
+}
+
+async function healthCheckAll() {
+    const targets = { scout: SCOUT_AGENT_URL, cfo: CFO_AGENT_URL, host: HOST_AGENT_URL };
+    const results = {};
+    await Promise.all(
+        Object.entries(targets).map(async ([name, url]) => {
+            try {
+                const resp = await fetch(`${url}/health`);
+                results[name] = resp.ok;
+            } catch {
+                results[name] = false;
+            }
+        })
+    );
+    return results;
+}
+
+module.exports = { triggerScoutScan, requestArtistPayout, requestHostNarration, healthCheckAll };

--- a/integrations/gcp_connector.py
+++ b/integrations/gcp_connector.py
@@ -1,0 +1,71 @@
+"""REST connector used by scripts/tests (and importable by any Python tooling
+around the existing Render/Supabase backend) to call the 3 GCP agents.
+
+The production Node backend (server-auto.js) is JS, not Python, so the actual
+in-process integration point there is `integrations/gcpConnector.js` (thin
+fetch-based twin of this module, same endpoints/contracts). This file is the
+one explicitly requested for the hackathon deliverable and is what
+scripts/demo.sh and tests/ use end-to-end.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import requests
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+@dataclass
+class GCPAgentsConnector:
+    scout_url: str = _env("SCOUT_AGENT_URL", "http://localhost:8081")
+    cfo_url: str = _env("CFO_AGENT_URL", "http://localhost:8082")
+    host_url: str = _env("HOST_AGENT_URL", "http://localhost:8083")
+    cfo_shared_secret: str = _env("CFO_AGENT_SHARED_SECRET", "")
+    timeout: int = 30
+
+    def trigger_scout_scan(self) -> dict[str, Any]:
+        resp = requests.post(f"{self.scout_url}/run", timeout=self.timeout)
+        resp.raise_for_status()
+        return resp.json()
+
+    def request_artist_payout(
+        self, payment_id: str, artist_user_id: str, battle_id: str, amount_usd: float
+    ) -> dict[str, Any]:
+        resp = requests.post(
+            f"{self.cfo_url}/payout",
+            json={
+                "payment_id": payment_id,
+                "artist_user_id": artist_user_id,
+                "battle_id": battle_id,
+                "amount_usd": amount_usd,
+            },
+            headers={"X-Agent-Secret": self.cfo_shared_secret},
+            timeout=self.timeout,
+        )
+        return resp.json()
+
+    def request_host_narration(
+        self, battle_id: str, event_type: str = "hype", message: str = ""
+    ) -> dict[str, Any]:
+        resp = requests.post(
+            f"{self.host_url}/narrate",
+            json={"battle_id": battle_id, "event_type": event_type, "message": message},
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def health_check_all(self) -> dict[str, Optional[bool]]:
+        results: dict[str, Optional[bool]] = {}
+        for name, url in (("scout", self.scout_url), ("cfo", self.cfo_url), ("host", self.host_url)):
+            try:
+                resp = requests.get(f"{url}/health", timeout=5)
+                results[name] = resp.ok
+            except Exception:  # noqa: BLE001
+                results[name] = False
+        return results

--- a/scripts/demo-dashboard.html
+++ b/scripts/demo-dashboard.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>MTR AI Ops — Demo Dashboard</title>
+<style>
+  :root {
+    --bg: #0b0f14; --panel: #131a22; --border: #23303c; --text: #e8eef4;
+    --muted: #8fa2b3; --accent: #33d17a; --warn: #f2b705; --bad: #ef5350;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; font-family: -apple-system, Segoe UI, Roboto, sans-serif;
+    background: var(--bg); color: var(--text); padding: 24px;
+  }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .sub { color: var(--muted); margin-bottom: 24px; font-size: 13px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 16px; }
+  .card {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 10px;
+    padding: 16px; display: flex; flex-direction: column; gap: 10px;
+  }
+  .card h2 { font-size: 15px; margin: 0; display: flex; align-items: center; gap: 8px; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--muted); display: inline-block; }
+  .dot.ok { background: var(--accent); }
+  .dot.bad { background: var(--bad); }
+  button {
+    background: #1c2833; color: var(--text); border: 1px solid var(--border);
+    border-radius: 6px; padding: 8px 12px; cursor: pointer; font-size: 13px;
+  }
+  button:hover { border-color: var(--accent); }
+  input {
+    background: #0e141b; color: var(--text); border: 1px solid var(--border);
+    border-radius: 6px; padding: 6px 8px; font-size: 12px; width: 100%;
+  }
+  label { font-size: 11px; color: var(--muted); }
+  pre {
+    background: #0e141b; border: 1px solid var(--border); border-radius: 6px;
+    padding: 10px; font-size: 11px; overflow-x: auto; margin: 0; max-height: 220px;
+    white-space: pre-wrap; word-break: break-word;
+  }
+  .flow { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--muted); margin: 16px 0; flex-wrap: wrap; }
+  .flow b { color: var(--text); }
+</style>
+</head>
+<body>
+  <h1>🎛️ MTR AI-Native Ops — Demo Dashboard</h1>
+  <div class="sub">Corriendo local (sin Docker): scout :8081 · cfo :8082 · host :8083</div>
+
+  <div class="flow">
+    <span><b>1. Scout</b> detecta artista</span> →
+    <span><b>2. Pago</b> llega vía NOWPayments (simulado)</span> →
+    <span><b>3. CFO</b> paga 95/5 (con guardrails)</span> →
+    <span><b>4. Host</b> narra el resultado</span> →
+    <span><b>5. Ledger</b> en BigQuery/local</span>
+  </div>
+
+  <div class="grid">
+    <div class="card">
+      <h2><span id="dot-scout" class="dot"></span> Scout Agent — A&amp;R IA</h2>
+      <button onclick="runScout()">Escanear Deezer ahora</button>
+      <pre id="out-scout">—</pre>
+    </div>
+
+    <div class="card">
+      <h2><span id="dot-cfo" class="dot"></span> CFO Agent — payments-agent</h2>
+      <label>artist_user_id (Supabase users.id)</label>
+      <input id="artistId" value="demo-artist-001" />
+      <label>amount_usd</label>
+      <input id="amountUsd" value="10" />
+      <button onclick="runCfo()">Procesar pago (split 95/5)</button>
+      <pre id="out-cfo">—</pre>
+    </div>
+
+    <div class="card">
+      <h2><span id="dot-host" class="dot"></span> Host Agent — battle-host-agent</h2>
+      <button onclick="runHost()">Narrar batalla</button>
+      <pre id="out-host">—</pre>
+    </div>
+
+    <div class="card">
+      <h2>📊 Resumen de la corrida</h2>
+      <pre id="out-summary">Todavía no se corrió nada.</pre>
+    </div>
+  </div>
+
+<script>
+const SCOUT = 'http://localhost:8081';
+const CFO = 'http://localhost:8082';
+const HOST = 'http://localhost:8083';
+const CFO_SECRET = 'demo-secret';
+
+async function checkHealth(url, dotId) {
+  try {
+    const r = await fetch(url + '/health');
+    document.getElementById(dotId).className = 'dot ' + (r.ok ? 'ok' : 'bad');
+  } catch { document.getElementById(dotId).className = 'dot bad'; }
+}
+checkHealth(SCOUT, 'dot-scout');
+checkHealth(CFO, 'dot-cfo');
+checkHealth(HOST, 'dot-host');
+
+let summary = {};
+function renderSummary() {
+  document.getElementById('out-summary').textContent = JSON.stringify(summary, null, 2);
+}
+
+async function runScout() {
+  const out = document.getElementById('out-scout');
+  out.textContent = 'Escaneando Deezer...';
+  try {
+    const r = await fetch(SCOUT + '/run', { method: 'POST' });
+    const data = await r.json();
+    out.textContent = JSON.stringify(data, null, 2);
+    summary.scout = { detections: data.detections };
+    renderSummary();
+  } catch (e) { out.textContent = 'Error: ' + e; }
+}
+
+async function runCfo() {
+  const out = document.getElementById('out-cfo');
+  out.textContent = 'Procesando pago...';
+  const artist_user_id = document.getElementById('artistId').value;
+  const amount_usd = parseFloat(document.getElementById('amountUsd').value);
+  try {
+    const r = await fetch(CFO + '/payout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Agent-Secret': CFO_SECRET },
+      body: JSON.stringify({
+        payment_id: 'demo-' + Date.now(),
+        artist_user_id, battle_id: 'demo-battle-001', amount_usd
+      })
+    });
+    const data = await r.json();
+    out.textContent = JSON.stringify(data, null, 2);
+    summary.cfo = { status: data.status, reason: data.reason, artist_amount_usd: data.artist_amount_usd };
+    renderSummary();
+  } catch (e) { out.textContent = 'Error: ' + e; }
+}
+
+async function runHost() {
+  const out = document.getElementById('out-host');
+  out.textContent = 'Generando narración...';
+  try {
+    const r = await fetch(HOST + '/narrate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ battle_id: 'demo-battle-001', event_type: 'hype' })
+    });
+    const data = await r.json();
+    out.textContent = JSON.stringify(data, null, 2);
+    summary.host = { reply: data.reply };
+    renderSummary();
+  } catch (e) { out.textContent = 'Error: ' + e; }
+}
+</script>
+</body>
+</html>

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# End-to-end demo: 1 artista detectado -> 1 pago recibido -> 1 pago enviado -> log en BigQuery.
+#
+# Assumes `docker-compose up --build` is already running (scout/cfo/host
+# agents + backend reachable at the URLs below). Uses the local fallbacks
+# (FIRESTORE_DISABLED/BIGQUERY_DISABLED) unless you've pointed agents/.env at
+# real GCP resources, in which case this exercises those for real.
+#
+# Usage:
+#   ARTIST_USER_ID=<a real Supabase users.id with wallet_address set> ./scripts/demo.sh
+
+set -euo pipefail
+
+SCOUT_URL="${SCOUT_AGENT_URL:-http://localhost:8081}"
+CFO_URL="${CFO_AGENT_URL:-http://localhost:8082}"
+HOST_URL="${HOST_AGENT_URL:-http://localhost:8083}"
+CFO_SECRET="${CFO_AGENT_SHARED_SECRET:-dev}"
+ARTIST_USER_ID="${ARTIST_USER_ID:-demo-artist-001}"
+BATTLE_ID="${BATTLE_ID:-demo-battle-001}"
+AMOUNT_USD="${AMOUNT_USD:-10}"
+
+echo "=== 0. Health check ==="
+for name_url in "scout:$SCOUT_URL" "cfo:$CFO_URL" "host:$HOST_URL"; do
+  name="${name_url%%:*}"
+  url="${name_url#*:}"
+  code=$(curl -s -o /dev/null -w "%{http_code}" "$url/health" || echo "000")
+  echo "  $name -> HTTP $code"
+done
+
+echo
+echo "=== 1. Artista detectado (Scout Agent) ==="
+curl -s -X POST "$SCOUT_URL/run" | tee /tmp/mtr_scout_result.json
+echo
+
+echo
+echo "=== 2. Pago recibido + enviado (CFO Agent, split 95/5) ==="
+PAYMENT_ID="demo-$(date +%s)"
+curl -s -X POST "$CFO_URL/payout" \
+  -H "Content-Type: application/json" \
+  -H "X-Agent-Secret: $CFO_SECRET" \
+  -d "{\"payment_id\":\"$PAYMENT_ID\",\"artist_user_id\":\"$ARTIST_USER_ID\",\"battle_id\":\"$BATTLE_ID\",\"amount_usd\":$AMOUNT_USD}" \
+  | tee /tmp/mtr_cfo_result.json
+echo
+
+echo
+echo "=== 3. Host narra el resultado en la batalla ==="
+curl -s -X POST "$HOST_URL/narrate" \
+  -H "Content-Type: application/json" \
+  -d "{\"battle_id\":\"$BATTLE_ID\",\"event_type\":\"hype\"}" \
+  | tee /tmp/mtr_host_result.json
+echo
+
+echo
+echo "=== 4. Log en BigQuery (o fallback local /tmp/bigquery_local.jsonl) ==="
+if [ -f /tmp/bigquery_local.jsonl ]; then
+  echo "Última fila del ledger:"
+  tail -n 1 /tmp/bigquery_local.jsonl
+else
+  echo "BIGQUERY_DISABLED=false detectado: revisa la tabla mtr_analytics.payments_ledger en BigQuery."
+fi
+
+echo
+echo "=== Demo completa: ${PAYMENT_ID} ==="

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "agents"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("FIRESTORE_DISABLED", "true")
+os.environ.setdefault("BIGQUERY_DISABLED", "true")
+os.environ.setdefault("USE_SECRET_MANAGER", "false")
+os.environ.setdefault("CFO_AGENT_SHARED_SECRET", "test-secret")
+os.environ.setdefault("BACKEND_INTERNAL_SECRET", "test-internal-secret")
+os.environ.setdefault("BQ_LOCAL_FALLBACK_PATH", os.path.join(os.path.dirname(__file__), "bigquery_local_test.jsonl"))

--- a/tests/test_cfo_agent.py
+++ b/tests/test_cfo_agent.py
@@ -1,0 +1,135 @@
+import cfo_agent
+from cfo_agent import PaymentEvent, process_payment
+
+
+def _reset_state():
+    cfo_agent.store._memory.clear()
+
+
+def test_rejects_non_positive_amount():
+    _reset_state()
+    result = process_payment(PaymentEvent("p1", "artist1", "battle1", 0))
+    assert result["status"] == "rejected"
+    assert result["reason"] == "non_positive_amount"
+
+
+def test_rejects_amount_over_per_tx_cap():
+    _reset_state()
+    over_cap = cfo_agent.PER_TX_CAP_USD + 1
+    result = process_payment(PaymentEvent("p2", "artist1", "battle1", over_cap))
+    assert result["status"] == "rejected"
+    assert "exceeds_per_tx_cap" in result["reason"]
+
+
+def test_rejects_when_no_wallet_on_file(monkeypatch):
+    _reset_state()
+    monkeypatch.setattr(cfo_agent.supabase, "get_artist_wallet", lambda uid: None)
+    result = process_payment(PaymentEvent("p3", "artist-no-wallet", "battle1", 10))
+    assert result["status"] == "rejected"
+    assert result["reason"] == "artist_wallet_not_on_file"
+
+
+def test_never_trusts_payload_wallet_uses_supabase_lookup(monkeypatch):
+    """The PaymentEvent has no wallet field at all — process_payment can only
+    ever pay out to whatever Supabase returns for the artist_user_id. This
+    test pins that contract so a future change can't accidentally start
+    trusting a caller-supplied wallet."""
+    _reset_state()
+    assert not hasattr(PaymentEvent, "wallet_address")
+
+    monkeypatch.setattr(cfo_agent.supabase, "get_artist_wallet", lambda uid: "0xVERIFIED")
+    monkeypatch.setattr(
+        cfo_agent.backend, "trigger_artist_payout", lambda **kwargs: {"txHash": "0xabc"}
+    )
+    result = process_payment(PaymentEvent("p4", "artist1", "battle1", 10))
+    assert result["artist_wallet"] == "0xVERIFIED"
+    assert result["status"] == "paid"
+
+
+def test_split_is_95_5_by_default(monkeypatch):
+    _reset_state()
+    monkeypatch.setattr(cfo_agent.supabase, "get_artist_wallet", lambda uid: "0xVERIFIED")
+    monkeypatch.setattr(
+        cfo_agent.backend, "trigger_artist_payout", lambda **kwargs: {"txHash": "0xabc"}
+    )
+    result = process_payment(PaymentEvent("p5", "artist1", "battle1", 100))
+    assert result["artist_amount_usd"] == 95
+    assert result["mtr_fee_usd"] == 5
+
+
+def test_duplicate_payment_id_is_idempotent(monkeypatch):
+    _reset_state()
+    monkeypatch.setattr(cfo_agent.supabase, "get_artist_wallet", lambda uid: "0xVERIFIED")
+    monkeypatch.setattr(
+        cfo_agent.backend, "trigger_artist_payout", lambda **kwargs: {"txHash": "0xabc"}
+    )
+    first = process_payment(PaymentEvent("dup1", "artist1", "battle1", 10))
+    second = process_payment(PaymentEvent("dup1", "artist1", "battle1", 10))
+    assert first["status"] == "paid"
+    assert second["status"] == "duplicate_ignored"
+
+
+def test_daily_cap_circuit_breaker_trips(monkeypatch):
+    _reset_state()
+    monkeypatch.setattr(cfo_agent.supabase, "get_artist_wallet", lambda uid: "0xVERIFIED")
+    monkeypatch.setattr(
+        cfo_agent.backend, "trigger_artist_payout", lambda **kwargs: {"txHash": "0xabc"}
+    )
+    monkeypatch.setattr(cfo_agent, "DAILY_CAP_USD", 15)
+
+    first = process_payment(PaymentEvent("d1", "artist1", "battle1", 10))
+    second = process_payment(PaymentEvent("d2", "artist1", "battle1", 10))
+
+    assert first["status"] == "paid"
+    assert second["status"] == "rejected"
+    assert "Daily cap exceeded" in second["reason"]
+
+
+def test_payout_endpoint_requires_shared_secret():
+    client = cfo_agent.app.test_client()
+    resp = client.post("/payout", json={})
+    assert resp.status_code == 401
+
+
+def test_dry_run_never_calls_backend_payout(monkeypatch):
+    _reset_state()
+    monkeypatch.setattr(cfo_agent.supabase, "get_artist_wallet", lambda uid: "0xVERIFIED")
+
+    called = {"count": 0}
+
+    def _should_never_run(**kwargs):
+        called["count"] += 1
+        return {"txHash": "0xshouldnothappen"}
+
+    monkeypatch.setattr(cfo_agent.backend, "trigger_artist_payout", _should_never_run)
+
+    result = process_payment(PaymentEvent("dry1", "artist1", "battle1", 10, dry_run=True))
+
+    assert result["status"] == "dry_run_ok"
+    assert result["artist_wallet"] == "0xVERIFIED"
+    assert result["artist_amount_usd"] == 9.5
+    assert called["count"] == 0, "dry_run must never call the real payout backend"
+
+
+def test_dry_run_still_respects_caps_and_wallet_checks(monkeypatch):
+    _reset_state()
+    monkeypatch.setattr(cfo_agent.supabase, "get_artist_wallet", lambda uid: None)
+    result = process_payment(PaymentEvent("dry2", "artist-no-wallet", "battle1", 10, dry_run=True))
+    assert result["status"] == "rejected"
+    assert result["reason"] == "artist_wallet_not_on_file"
+
+
+def test_payout_endpoint_happy_path(monkeypatch):
+    _reset_state()
+    monkeypatch.setattr(cfo_agent.supabase, "get_artist_wallet", lambda uid: "0xVERIFIED")
+    monkeypatch.setattr(
+        cfo_agent.backend, "trigger_artist_payout", lambda **kwargs: {"txHash": "0xabc"}
+    )
+    client = cfo_agent.app.test_client()
+    resp = client.post(
+        "/payout",
+        json={"payment_id": "e1", "artist_user_id": "a1", "battle_id": "b1", "amount_usd": 10},
+        headers={"X-Agent-Secret": cfo_agent.SHARED_SECRET},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "paid"

--- a/tests/test_host_agent.py
+++ b/tests/test_host_agent.py
@@ -1,0 +1,37 @@
+import host_agent
+
+
+def test_build_battle_context_without_data_is_safe(monkeypatch):
+    monkeypatch.setattr(host_agent.supabase, "get_active_battle", lambda battle_id: None)
+    context = host_agent.build_battle_context("missing-battle")
+    assert "missing-battle" in context
+
+
+def test_generate_reply_falls_back_without_vertex_credentials(monkeypatch):
+    """No GCP_PROJECT_ID / Vertex AI credentials configured in the test env ->
+    generate_reply must never raise, it must use the deterministic fallback."""
+    monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
+    monkeypatch.setattr(host_agent.supabase, "get_active_battle", lambda battle_id: None)
+    reply = host_agent.generate_reply("b1", "hype")
+    assert isinstance(reply, str)
+    assert len(reply) > 0
+
+
+def test_fallback_reply_never_leaks_internal_terms():
+    reply = host_agent._fallback_reply("hype", "Batalla b1 — A vs B. Marcador: 3 - 2.")
+    forbidden = ["private_key", "wallet_address", "secret", "vault_wallet"]
+    assert not any(term in reply.lower() for term in forbidden)
+
+
+def test_narrate_endpoint_requires_battle_id():
+    client = host_agent.app.test_client()
+    resp = client.post("/narrate", json={"event_type": "hype"})
+    assert resp.status_code == 400
+
+
+def test_narrate_endpoint_happy_path(monkeypatch):
+    monkeypatch.setattr(host_agent, "generate_reply", lambda battle_id, event_type, user_message="": "¡Vamos!")
+    client = host_agent.app.test_client()
+    resp = client.post("/narrate", json={"battle_id": "b1", "event_type": "hype"})
+    assert resp.status_code == 200
+    assert resp.get_json()["reply"] == "¡Vamos!"

--- a/tests/test_scout_agent.py
+++ b/tests/test_scout_agent.py
@@ -1,0 +1,47 @@
+import scout_agent
+
+
+def test_compute_growth_no_baseline_returns_none():
+    scout_agent.store._memory.clear()
+    artist = {"id": 1, "name": "New Artist", "nb_fan": 1000}
+    assert scout_agent.compute_growth(artist) is None
+
+
+def test_compute_growth_detects_threshold_breach():
+    scout_agent.store._memory.clear()
+    scout_agent.store.set(
+        scout_agent.SNAPSHOT_COLLECTION, "1", {"artist_id": "1", "nb_fan": 1000}
+    )
+    artist = {"id": 1, "name": "Rising Star", "nb_fan": 1250, "link": "https://deezer.com/1"}
+    detection = scout_agent.compute_growth(artist)
+    assert detection is not None
+    assert detection["growth_pct"] == 25.0
+
+
+def test_compute_growth_below_threshold_returns_none():
+    scout_agent.store._memory.clear()
+    scout_agent.store.set(scout_agent.SNAPSHOT_COLLECTION, "2", {"artist_id": "2", "nb_fan": 1000})
+    artist = {"id": 2, "name": "Steady Artist", "nb_fan": 1050}
+    assert scout_agent.compute_growth(artist) is None
+
+
+def test_send_invite_without_smtp_config_is_noop(monkeypatch):
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    detection = {"name": "X", "growth_pct": 30, "prev_fans": 10, "current_fans": 13, "deezer_link": "l"}
+    assert scout_agent.send_invite(detection) is False
+
+
+def test_run_scan_logs_detections(monkeypatch):
+    scout_agent.store._memory.clear()
+    scout_agent.store.set(scout_agent.SNAPSHOT_COLLECTION, "9", {"artist_id": "9", "nb_fan": 100})
+
+    monkeypatch.setattr(
+        scout_agent,
+        "fetch_trending_artists",
+        lambda limit=50: [{"id": 9, "name": "Grower", "nb_fan": 130, "link": "l"}],
+    )
+    monkeypatch.setattr(scout_agent, "send_invite", lambda detection: False)
+
+    detections = scout_agent.run_scan()
+    assert len(detections) == 1
+    assert detections[0]["name"] == "Grower"


### PR DESCRIPTION
- 3 agentes (scout, cfo, host) en agents/, con guardrails contra el patron de vulnerabilidad ya documentado en ANALISIS-VULNERABILIDAD-CONFIRMADA.md (wallet siempre desde Supabase, nunca del payload; idempotencia; topes por tx/dia con circuit breaker; sin clave privada propia).
- Nueva ruta interna /api/internal/agent-payout en backend/server-auto.js (aditiva, protegida por requireInternalSecret existente, reusa prize-service.js::sendPrize).
- Conectores Python/JS en integrations/.
- docker-compose.yml + Dockerfile para correr todo local.
- Tests en tests/ (pytest) para los 3 agentes.
- Docs: ARCHITECTURE.md, DEPLOY_GCP.md, agents/README.md, PITCH.md.
- scripts/demo.sh y scripts/demo-dashboard.html para la demo end-to-end.

Ya desplegado y verificado en GCP (proyecto mtr-ai-ops-2026): scout-agent y host-agent publicos, cfo-agent detras de IAM. Split 95/5 y wallet lookup verificados en modo dry_run contra Supabase de produccion.