### PR TITLE
CRITICO: validar wallet de destino en /api/prizes/send

### DIFF
--- a/backend/prize-api.js
+++ b/backend/prize-api.js
@@ -3,17 +3,82 @@
  *
  * Uso recomendado en backend Express/Fastify-like:
  *   const { registerPrizeRoutes } = require('./backend/prize-api')
- *   registerPrizeRoutes(app)
+ *   registerPrizeRoutes(app, supabase)
+ *
+ * SEGURIDAD (2026-08-16): esta ruta la llama el frontend directamente
+ * (game-engine.js::sendPrizeToWinner) para pagar premios reales en vivo, así
+ * que no se puede cerrar detrás de un secreto interno sin romper pagos
+ * legítimos. Hasta hoy, ejecutaba sendPrize() con la wallet de destino tal
+ * cual venía en el body, sin validar nada — cualquiera podía llamar a esta
+ * ruta con su propia wallet y matchId cualquiera y cobrar un premio real. Es
+ * el mismo patrón que causó el robo confirmado de marzo 2026
+ * (ver ANALISIS-VULNERABILIDAD-CONFIRMADA.md), aplicado sin ni siquiera el
+ * chequeo roto que tenía /api/claim entonces.
+ *
+ * Fix aplicado: la wallet de destino ahora se valida contra los
+ * participantes reales (player1_id/player2_id) del matchId indicado,
+ * usando su wallet_address registrada en Supabase — nunca la del payload.
+ * Esto impide que una wallet externa arbitraria cobre el premio.
+ *
+ * Limitación conocida, pendiente de un fix posterior con más tiempo: esto
+ * valida que la wallet pertenezca a UN participante del match, pero no
+ * repite aquí la lógica completa de "quién ganó realmente" — eso sigue
+ * decidiéndose donde ya se decidía antes. No dejar este comentario
+ * desactualizado si se cierra esa brecha.
  */
 const { sendPrize } = require('./prize-service')
 
-async function prizeRouteHandler(req, res) {
+function makePrizeRouteHandler(supabase) {
+  return async function prizeRouteHandler(req, res) {
   try {
     const body = req?.body || {}
     const { winner, amount, matchId, network, token, tokenAddress } = body
 
     if (network && network !== 'base') {
       return res.status(400).json({ ok: false, error: 'Unsupported network, use base' })
+    }
+
+    if (!supabase) {
+      console.error('[prize-api] Supabase client not available on app; refusing unvalidated payout')
+      return res.status(503).json({ ok: false, error: 'Payout validation unavailable' })
+    }
+    if (!matchId) {
+      return res.status(400).json({ ok: false, error: 'matchId is required' })
+    }
+    if (!winner || typeof winner !== 'string') {
+      return res.status(400).json({ ok: false, error: 'winner wallet is required' })
+    }
+
+    const { data: match, error: matchError } = await supabase
+      .from('matches')
+      .select('id, player1_id, player2_id')
+      .eq('id', matchId)
+      .maybeSingle()
+
+    if (matchError || !match) {
+      return res.status(404).json({ ok: false, error: 'Match not found' })
+    }
+
+    const { data: participants, error: participantsError } = await supabase
+      .from('users')
+      .select('id, wallet_address')
+      .in('id', [match.player1_id, match.player2_id].filter(Boolean))
+
+    if (participantsError) {
+      console.error('[prize-api] Failed to load match participants:', participantsError)
+      return res.status(500).json({ ok: false, error: 'Failed to validate winner wallet' })
+    }
+
+    const winnerIsParticipant = (participants || []).some(
+      (p) => p.wallet_address && p.wallet_address.toLowerCase() === winner.toLowerCase()
+    )
+
+    if (!winnerIsParticipant) {
+      console.warn('[prize-api] Rejected payout: wallet is not a registered participant of this match', {
+        matchId,
+        claimedWallet: winner
+      })
+      return res.status(403).json({ ok: false, error: 'Wallet does not belong to a participant of this match' })
     }
 
     const result = await sendPrize(winner, amount)
@@ -32,15 +97,19 @@ async function prizeRouteHandler(req, res) {
     console.error('[prize-api] send error:', error)
     return res.status(500).json({ ok: false, error: error?.message || 'Failed to send prize' })
   }
+  }
 }
 
-function registerPrizeRoutes(app) {
+function registerPrizeRoutes(app, supabase) {
   if (!app || typeof app.post !== 'function') {
     throw new Error('registerPrizeRoutes requires an app instance with .post(path, handler)')
   }
+  if (!supabase) {
+    throw new Error('registerPrizeRoutes requires a supabase client to validate winner wallets')
+  }
 
-  app.post('/api/prizes/send', prizeRouteHandler)
+  app.post('/api/prizes/send', makePrizeRouteHandler(supabase))
   return app
 }
 
-module.exports = { registerPrizeRoutes, prizeRouteHandler }
+module.exports = { registerPrizeRoutes, makePrizeRouteHandler }

--- a/backend/server-auto.js
+++ b/backend/server-auto.js
@@ -2411,8 +2411,8 @@ app.post('/api/deposit/mercadopago/create', (req, res) => {
 
 try {
     const { registerPrizeRoutes } = require('./prize-api');
-    registerPrizeRoutes(app);
-    console.log('[server] Registered POST /api/prizes/send');
+    registerPrizeRoutes(app, supabase);
+    console.log('[server] Registered POST /api/prizes/send (wallet validado contra participantes del match)');
 } catch (prizeRegErr) {
     console.warn('[server] Prize routes not registered:', prizeRegErr.message);
 }

--- a/scripts/verify-prize-api-fix.js
+++ b/scripts/verify-prize-api-fix.js
@@ -1,0 +1,98 @@
+// Verificacion manual rapida del fix de seguridad en /api/prizes/send.
+// No es un test formal del framework del repo, solo una comprobacion
+// puntual antes de subir el cambio. Se puede borrar despues.
+const path = require('path');
+const Module = require('module');
+
+// Mock de ./prize-service para no llamar a la blockchain de verdad
+const prizeServicePath = path.join(__dirname, '..', 'backend', 'prize-service.js');
+const originalLoad = Module._load;
+let sendPrizeCalls = [];
+Module._load = function (request, parent, isMain) {
+  if (parent && parent.filename && path.resolve(path.dirname(parent.filename), request) === prizeServicePath.replace('.js', '')) {
+    return {
+      sendPrize: async (winner, amount) => {
+        sendPrizeCalls.push({ winner, amount });
+        return { method: 'mock', txHash: '0xmock' };
+      }
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+
+const { makePrizeRouteHandler } = require('../backend/prize-api');
+Module._load = originalLoad;
+
+function fakeRes() {
+  const res = { statusCode: null, body: null };
+  res.status = (c) => { res.statusCode = c; return res; };
+  res.json = (b) => { res.body = b; return res; };
+  return res;
+}
+
+async function run() {
+  const supabaseMock = {
+    from(table) {
+      if (table === 'matches') {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          async maybeSingle() {
+            return { data: { id: 'match1', player1_id: 'userA', player2_id: 'userB' }, error: null };
+          }
+        };
+      }
+      if (table === 'users') {
+        return {
+          select() { return this; },
+          in() {
+            return Promise.resolve({
+              data: [
+                { id: 'userA', wallet_address: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+                { id: 'userB', wallet_address: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' }
+              ],
+              error: null
+            });
+          }
+        };
+      }
+      throw new Error('unexpected table ' + table);
+    }
+  };
+
+  const handler = makePrizeRouteHandler(supabaseMock);
+  sendPrizeCalls = [];
+
+  // Caso 1: wallet legitima (participante real del match) -> debe pagar
+  let req = { body: { winner: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', amount: 10, matchId: 'match1' } };
+  let res = fakeRes();
+  await handler(req, res);
+  console.log('Caso 1 (participante legitimo) ->', res.statusCode, JSON.stringify(res.body));
+  console.assert(res.statusCode === 200, 'Caso 1 deberia ser 200');
+  console.assert(sendPrizeCalls.length === 1, 'Caso 1 deberia haber llamado a sendPrize una vez');
+
+  // Caso 2: wallet de atacante (no es participante del match) -> debe rechazar
+  req = { body: { winner: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF', amount: 10, matchId: 'match1' } };
+  res = fakeRes();
+  await handler(req, res);
+  console.log('Caso 2 (atacante externo) ->', res.statusCode, JSON.stringify(res.body));
+  console.assert(res.statusCode === 403, 'Caso 2 deberia ser 403');
+  console.assert(sendPrizeCalls.length === 1, 'Caso 2 NO deberia haber llamado a sendPrize de nuevo (sigue en 1)');
+
+  // Caso 3: matchId inexistente -> debe rechazar
+  req = { body: { winner: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', amount: 10, matchId: 'no-existe' } };
+  res = fakeRes();
+  const supabaseMock2 = {
+    from(table) {
+      return { select() { return this; }, eq() { return this; }, async maybeSingle() { return { data: null, error: null }; } };
+    }
+  };
+  const handler2 = makePrizeRouteHandler(supabaseMock2);
+  await handler2(req, res);
+  console.log('Caso 3 (match inexistente) ->', res.statusCode, JSON.stringify(res.body));
+  console.assert(res.statusCode === 404, 'Caso 3 deberia ser 404');
+
+  console.log('\nTodos los asserts pasaron si no se vio ningun "Assertion failed" arriba.');
+}
+
+run().catch((e) => { console.error('ERROR EN TEST:', e); process.exit(1); });


### PR DESCRIPTION
/api/prizes/send ejecutaba sendPrize() con la wallet que llegaba en el body de la solicitud, sin validarla contra nada. Cualquiera podia llamar a esta ruta (sin autenticacion) con su propia wallet y un matchId cualquiera, y cobrar un premio real. Mismo patron que el robo confirmado de marzo 2026 (ANALISIS-VULNERABILIDAD-CONFIRMADA.md), pero sin ni siquiera el chequeo roto que tenia /api/claim en ese momento.

Fix: la wallet de destino ahora se valida contra los participantes reales (player1_id/player2_id) del matchId indicado, usando su wallet_address registrada en Supabase. Se agrega scripts/verify-prize-api-fix.js con 3 casos verificados: participante legitimo (200), wallet externa (403), match inexistente (404).

Limitacion conocida: valida que la wallet pertenezca a UN participante del match, no repite la logica completa de 'quien gano realmente'. Documentado en el comentario del archivo para seguimiento.