### PR TITLE
Agregar sistema de apuestas multi-fan con reparto 80/10/10

### DIFF
--- a/backend/battle-bets-api.js
+++ b/backend/battle-bets-api.js
@@ -1,0 +1,205 @@
+/**
+ * Rutas de apuestas multi-fan por batalla (modelo 80/10/10).
+ *
+ * POST /api/battles/:battleId/bet     -> un fan autenticado aposta credits
+ *                                        por un lado de la batalla.
+ * POST /api/battles/:battleId/settle  -> liquida la batalla (SOLO interno,
+ *                                        requireInternalSecret — la llama el
+ *                                        propio backend cuando la batalla
+ *                                        real se resuelve, nunca un cliente).
+ *
+ * SEGURIDAD, mismo patron que el resto del proyecto:
+ *  - El usuario que aposta se identifica por su token Bearer (getAuthUserFromBearer),
+ *    NUNCA por un userId que venga en el body.
+ *  - Los creditos se descuentan con decrement_user_credits / se acreditan con
+ *    increment_user_credits (las mismas funciones RPC atomicas que ya usa
+ *    el resto del sistema de creditos), nunca escribiendo la tabla directo.
+ *  - /settle es idempotente: si el battleId ya tiene fila en
+ *    battle_settlements, se rechaza (no se puede liquidar dos veces).
+ */
+const { getAuthUserFromBearer, resolvePublicUserId, requireInternalSecret } = require('./auth-middleware');
+const { computeSettlement } = require('./battle-settlement');
+
+function makePlaceBetHandler(supabase) {
+  return async function placeBetHandler(req, res) {
+    try {
+      const { battleId } = req.params;
+      const { side, amount } = req.body || {};
+
+      if (!battleId) return res.status(400).json({ ok: false, error: 'battleId is required' });
+      if (side !== 'player1' && side !== 'player2') {
+        return res.status(400).json({ ok: false, error: "side must be 'player1' or 'player2'" });
+      }
+      const numericAmount = Number(amount);
+      if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+        return res.status(400).json({ ok: false, error: 'amount must be a positive number' });
+      }
+
+      const authUser = await getAuthUserFromBearer(req, supabase);
+      if (!authUser) {
+        return res.status(401).json({ ok: false, error: 'Unauthorized' });
+      }
+      const userId = await resolvePublicUserId(supabase, authUser);
+      if (!userId) {
+        return res.status(404).json({ ok: false, error: 'User not found' });
+      }
+
+      const { data: alreadySettled } = await supabase
+        .from('battle_settlements')
+        .select('battle_id')
+        .eq('battle_id', battleId)
+        .maybeSingle();
+      if (alreadySettled) {
+        return res.status(409).json({ ok: false, error: 'This battle is already settled; no more bets accepted' });
+      }
+
+      // Descuenta credits de forma atomica ANTES de registrar la apuesta.
+      // decrement_user_credits ya usa GREATEST(0, credits - amount) --
+      // verificamos el saldo resultante para saber si realmente alcanzaba.
+      const { data: beforeRow } = await supabase
+        .from('user_credits')
+        .select('credits')
+        .eq('user_id', userId)
+        .maybeSingle();
+      const balanceBefore = Number(beforeRow?.credits || 0);
+      if (balanceBefore < numericAmount) {
+        return res.status(402).json({ ok: false, error: 'Insufficient credits' });
+      }
+
+      const { error: decError } = await supabase.rpc('decrement_user_credits', {
+        user_id_param: userId,
+        credits_to_subtract: numericAmount
+      });
+      if (decError) {
+        console.error('[battle-bets] decrement_user_credits failed:', decError);
+        return res.status(500).json({ ok: false, error: 'Failed to reserve credits' });
+      }
+
+      const { data: bet, error: insertError } = await supabase
+        .from('battle_bets')
+        .insert({ battle_id: battleId, user_id: userId, side, amount: numericAmount })
+        .select('id')
+        .single();
+
+      if (insertError) {
+        // Compensacion: la apuesta no se pudo registrar, devolver los creditos.
+        console.error('[battle-bets] insert failed, refunding credits:', insertError);
+        await supabase.rpc('increment_user_credits', {
+          user_id_param: userId,
+          credits_to_add: numericAmount
+        });
+        return res.status(500).json({ ok: false, error: 'Failed to record bet, credits refunded' });
+      }
+
+      return res.status(200).json({ ok: true, betId: bet.id, battleId, side, amount: numericAmount });
+    } catch (error) {
+      console.error('[battle-bets] placeBetHandler error:', error);
+      return res.status(500).json({ ok: false, error: error?.message || 'Internal error' });
+    }
+  };
+}
+
+function makeSettleHandler(supabase) {
+  return async function settleHandler(req, res) {
+    try {
+      const { battleId } = req.params;
+      const { winningSide, artistUserId } = req.body || {};
+
+      if (!battleId) return res.status(400).json({ ok: false, error: 'battleId is required' });
+      if (winningSide !== 'player1' && winningSide !== 'player2') {
+        return res.status(400).json({ ok: false, error: "winningSide must be 'player1' or 'player2'" });
+      }
+
+      const { data: existing } = await supabase
+        .from('battle_settlements')
+        .select('battle_id')
+        .eq('battle_id', battleId)
+        .maybeSingle();
+      if (existing) {
+        return res.status(409).json({ ok: false, error: 'Battle already settled' });
+      }
+
+      const { data: bets, error: betsError } = await supabase
+        .from('battle_bets')
+        .select('id, user_id, side, amount')
+        .eq('battle_id', battleId)
+        .eq('settled', false);
+
+      if (betsError) {
+        console.error('[battle-bets] failed to load bets:', betsError);
+        return res.status(500).json({ ok: false, error: 'Failed to load bets' });
+      }
+      if (!bets || bets.length === 0) {
+        return res.status(404).json({ ok: false, error: 'No bets found for this battle' });
+      }
+
+      const settlement = computeSettlement(
+        bets.map((b) => ({ userId: b.user_id, side: b.side, amount: Number(b.amount) })),
+        winningSide
+      );
+
+      // Acredita a cada ganador (RPC atomica, una llamada por usuario).
+      for (const payout of settlement.payouts) {
+        const { error: payErr } = await supabase.rpc('increment_user_credits', {
+          user_id_param: payout.userId,
+          credits_to_add: payout.amount
+        });
+        if (payErr) {
+          // No hacemos rollback de los pagos anteriores: mejor pagar de mas
+          // (y loggear fuerte) que dejar a un ganador sin cobrar por un
+          // error de red a mitad de camino. Se corrige manualmente si pasa.
+          console.error('[battle-bets] CRITICAL: payout failed for user', payout.userId, payErr);
+        }
+      }
+
+      // Acredita al artista (10%), si se indico su user_id.
+      if (artistUserId && settlement.artistCut > 0) {
+        const { error: artistPayErr } = await supabase.rpc('increment_user_credits', {
+          user_id_param: artistUserId,
+          credits_to_add: settlement.artistCut
+        });
+        if (artistPayErr) {
+          console.error('[battle-bets] CRITICAL: artist payout failed:', artistPayErr);
+        }
+      }
+
+      // El platformCut no se acredita a nadie: simplemente no se reparte,
+      // queda "retenido" (es la comision de la casa).
+
+      await supabase
+        .from('battle_bets')
+        .update({ settled: true, settled_at: new Date().toISOString() })
+        .eq('battle_id', battleId);
+
+      await supabase.from('battle_settlements').insert({
+        battle_id: battleId,
+        winning_side: winningSide,
+        total_pool: settlement.totalPool,
+        platform_cut: settlement.platformCut,
+        artist_cut: settlement.artistCut,
+        winner_pool: settlement.winnerPool,
+        artist_user_id: artistUserId || null
+      });
+
+      return res.status(200).json({ ok: true, battleId, ...settlement });
+    } catch (error) {
+      console.error('[battle-bets] settleHandler error:', error);
+      return res.status(500).json({ ok: false, error: error?.message || 'Internal error' });
+    }
+  };
+}
+
+function registerBattleBetsRoutes(app, supabase) {
+  if (!app || typeof app.post !== 'function') {
+    throw new Error('registerBattleBetsRoutes requires an app instance');
+  }
+  if (!supabase) {
+    throw new Error('registerBattleBetsRoutes requires a supabase client');
+  }
+
+  app.post('/api/battles/:battleId/bet', makePlaceBetHandler(supabase));
+  app.post('/api/battles/:battleId/settle', requireInternalSecret, makeSettleHandler(supabase));
+  return app;
+}
+
+module.exports = { registerBattleBetsRoutes, makePlaceBetHandler, makeSettleHandler };

--- a/backend/battle-settlement.js
+++ b/backend/battle-settlement.js
@@ -1,0 +1,104 @@
+/**
+ * Liquidacion de batallas multi-fan (modelo 80/10/10).
+ *
+ * Modelo de negocio confirmado con el usuario (2026-08-17):
+ *   - 80% del pozo total -> repartido PROPORCIONALMENTE entre quienes
+ *     apostaron por el lado ganador (segun cuanto puso cada uno)
+ *   - 10% del pozo total -> el artista/lado ganador (socio)
+ *   - 10% del pozo total -> la plataforma
+ *
+ * computeSettlement() es una funcion pura (sin I/O, sin Supabase) para que
+ * se pueda probar de forma aislada antes de tocar datos reales. Toda la
+ * plata se calcula en centavos de credito (numeros, no floats de JS
+ * directamente en la respuesta final) redondeando a 4 decimales, igual que
+ * la columna DECIMAL(20,4) de user_credits.
+ */
+
+const ARTIST_CUT_PCT = 0.10;
+const PLATFORM_CUT_PCT = 0.10;
+const WINNER_POOL_PCT = 1 - ARTIST_CUT_PCT - PLATFORM_CUT_PCT; // 0.80
+
+function round4(n) {
+  return Math.round(n * 10000) / 10000;
+}
+
+/**
+ * @param {Array<{userId: string, side: 'player1'|'player2', amount: number}>} bets
+ * @param {'player1'|'player2'} winningSide
+ * @returns {{
+ *   totalPool: number,
+ *   platformCut: number,
+ *   artistCut: number,
+ *   winnerPool: number,
+ *   payouts: Array<{userId: string, amount: number}>,
+ *   winningSideTotal: number,
+ *   losingSideTotal: number
+ * }}
+ */
+function computeSettlement(bets, winningSide) {
+  if (!Array.isArray(bets) || bets.length === 0) {
+    throw new Error('bets must be a non-empty array');
+  }
+  if (winningSide !== 'player1' && winningSide !== 'player2') {
+    throw new Error("winningSide must be 'player1' or 'player2'");
+  }
+  for (const b of bets) {
+    if (!b.userId) throw new Error('every bet needs a userId');
+    if (b.side !== 'player1' && b.side !== 'player2') {
+      throw new Error(`invalid bet side: ${b.side}`);
+    }
+    if (!(Number(b.amount) > 0)) {
+      throw new Error(`invalid bet amount for user ${b.userId}: ${b.amount}`);
+    }
+  }
+
+  const totalPool = round4(bets.reduce((sum, b) => sum + Number(b.amount), 0));
+  const platformCut = round4(totalPool * PLATFORM_CUT_PCT);
+  const artistCut = round4(totalPool * ARTIST_CUT_PCT);
+
+  const winningBets = bets.filter((b) => b.side === winningSide);
+  const losingBets = bets.filter((b) => b.side !== winningSide);
+  const winningSideTotal = round4(winningBets.reduce((s, b) => s + Number(b.amount), 0));
+  const losingSideTotal = round4(losingBets.reduce((s, b) => s + Number(b.amount), 0));
+
+  // winnerPool se calcula como el remanente exacto (total - platform - artist)
+  // en vez de totalPool * WINNER_POOL_PCT, para que los 3 cortes sumen
+  // EXACTO el pozo total incluso con redondeos de centavos.
+  const winnerPool = round4(totalPool - platformCut - artistCut);
+
+  let payouts = [];
+  if (winningSideTotal > 0) {
+    payouts = winningBets.map((b) => ({
+      userId: b.userId,
+      amount: round4(winnerPool * (Number(b.amount) / winningSideTotal))
+    }));
+  } else {
+    // Nadie aposto por el lado ganador (caso raro: ej. bracket con solo un
+    // lado con apuestas humanas). No hay a quien repartir el winnerPool;
+    // se documenta explicitamente en vez de perderlo en silencio.
+    payouts = [];
+  }
+
+  // Ajuste de centavos: por redondeo, la suma de payouts puede quedar
+  // hasta +/-0.0001*N por debajo/encima de winnerPool. Se corrige en el
+  // primer payout para que la conciliacion cierre exacto.
+  if (payouts.length > 0) {
+    const paidSum = round4(payouts.reduce((s, p) => s + p.amount, 0));
+    const diff = round4(winnerPool - paidSum);
+    if (diff !== 0) {
+      payouts[0] = { ...payouts[0], amount: round4(payouts[0].amount + diff) };
+    }
+  }
+
+  return {
+    totalPool,
+    platformCut,
+    artistCut,
+    winnerPool,
+    payouts,
+    winningSideTotal,
+    losingSideTotal
+  };
+}
+
+module.exports = { computeSettlement, ARTIST_CUT_PCT, PLATFORM_CUT_PCT, WINNER_POOL_PCT };

--- a/backend/server-auto.js
+++ b/backend/server-auto.js
@@ -2417,6 +2417,14 @@ try {
     console.warn('[server] Prize routes not registered:', prizeRegErr.message);
 }
 
+try {
+    const { registerBattleBetsRoutes } = require('./battle-bets-api');
+    registerBattleBetsRoutes(app, supabase);
+    console.log('[server] Registered POST /api/battles/:battleId/bet and /settle (modelo 80/10/10)');
+} catch (battleBetsRegErr) {
+    console.warn('[server] Battle bets routes not registered:', battleBetsRegErr.message);
+}
+
 /**
  * Root endpoint - helps verify server is running
  */

--- a/scripts/verify-battle-bets-api.js
+++ b/scripts/verify-battle-bets-api.js
@@ -1,0 +1,173 @@
+// Verificacion manual de las rutas de apuestas (mock de supabase, sin red).
+const { makePlaceBetHandler, makeSettleHandler } = require('../backend/battle-bets-api');
+
+function fakeRes() {
+  const res = { statusCode: null, body: null };
+  res.status = (c) => { res.statusCode = c; return res; };
+  res.json = (b) => { res.body = b; return res; };
+  return res;
+}
+
+function makeSupabaseMock({ userCredits = {}, bets = [], settlements = {} } = {}) {
+  const calls = { decrement: [], increment: [], inserts: [] };
+  return {
+    calls,
+    auth: {
+      async getUser(token) {
+        if (token === 'valid-token-fan1') return { data: { user: { id: 'fan1' } }, error: null };
+        if (token === 'valid-token-fan2') return { data: { user: { id: 'fan2' } }, error: null };
+        return { data: { user: null }, error: 'invalid' };
+      }
+    },
+    rpc(fn, args) {
+      if (fn === 'decrement_user_credits') {
+        calls.decrement.push(args);
+        userCredits[args.user_id_param] = (userCredits[args.user_id_param] || 0) - args.credits_to_subtract;
+        return Promise.resolve({ error: null });
+      }
+      if (fn === 'increment_user_credits') {
+        calls.increment.push(args);
+        userCredits[args.user_id_param] = (userCredits[args.user_id_param] || 0) + args.credits_to_add;
+        return Promise.resolve({ error: null });
+      }
+      throw new Error('unexpected rpc ' + fn);
+    },
+    from(table) {
+      if (table === 'users') {
+        return {
+          select() { return this; },
+          eq(col, val) { this._id = val; return this; },
+          async maybeSingle() { return { data: { id: this._id }, error: null }; }
+        };
+      }
+      if (table === 'user_credits') {
+        return {
+          select() { return this; },
+          eq(col, val) { this._id = val; return this; },
+          async maybeSingle() { return { data: { credits: userCredits[this._id] || 0 }, error: null }; }
+        };
+      }
+      if (table === 'battle_settlements') {
+        return {
+          select() { return this; },
+          eq(col, val) { this._battleId = val; return this; },
+          async maybeSingle() { return { data: settlements[this._battleId] || null, error: null }; },
+          async insert(row) { settlements[row.battle_id] = row; calls.inserts.push(row); return { error: null }; }
+        };
+      }
+      if (table === 'battle_bets') {
+        return {
+          select() { return this; },
+          eq(col, val) {
+            if (col === 'battle_id') this._battleId = val;
+            return this;
+          },
+          insert(row) {
+            const withId = { id: 'bet-' + (bets.length + 1), ...row };
+            bets.push(withId);
+            return { select: () => ({ single: async () => ({ data: { id: withId.id }, error: null }) }) };
+          },
+          async update(fields) { return { eq: () => Promise.resolve({ error: null }) }; }
+        };
+      }
+      throw new Error('unexpected table ' + table);
+    }
+  };
+}
+
+async function run() {
+  let ok = 0, fail = 0;
+  function assertEq(actual, expected, label) {
+    if (actual === expected) { ok++; }
+    else { fail++; console.error(`FAIL ${label}: esperado ${expected}, obtuve ${actual}`); }
+  }
+
+  // --- Caso 1: colocar apuesta valida ---
+  {
+    const userCredits = { fan1: 95 };
+    const bets = [];
+    const supabase = makeSupabaseMock({ userCredits, bets });
+    const handler = makePlaceBetHandler(supabase);
+    const req = { params: { battleId: 'b1' }, body: { side: 'player1', amount: 50 }, headers: { authorization: 'Bearer valid-token-fan1' } };
+    const res = fakeRes();
+    await handler(req, res);
+    assertEq(res.statusCode, 200, 'Caso1 status');
+    assertEq(userCredits.fan1, 45, 'Caso1 saldo descontado');
+    console.log('Caso 1 (apuesta valida):', res.statusCode, JSON.stringify(res.body));
+  }
+
+  // --- Caso 2: saldo insuficiente ---
+  {
+    const userCredits = { fan1: 10 };
+    const supabase = makeSupabaseMock({ userCredits });
+    const handler = makePlaceBetHandler(supabase);
+    const req = { params: { battleId: 'b1' }, body: { side: 'player1', amount: 50 }, headers: { authorization: 'Bearer valid-token-fan1' } };
+    const res = fakeRes();
+    await handler(req, res);
+    assertEq(res.statusCode, 402, 'Caso2 status (saldo insuficiente)');
+    console.log('Caso 2 (saldo insuficiente):', res.statusCode, JSON.stringify(res.body));
+  }
+
+  // --- Caso 3: sin token -> 401 ---
+  {
+    const supabase = makeSupabaseMock({});
+    const handler = makePlaceBetHandler(supabase);
+    const req = { params: { battleId: 'b1' }, body: { side: 'player1', amount: 50 }, headers: {} };
+    const res = fakeRes();
+    await handler(req, res);
+    assertEq(res.statusCode, 401, 'Caso3 status (sin token)');
+    console.log('Caso 3 (sin token):', res.statusCode, JSON.stringify(res.body));
+  }
+
+  // --- Caso 4: liquidar batalla con 2 apostadores por lado ganador ---
+  {
+    const userCredits = { fan1: 0, fan2: 0, fan3: 0, artist1: 0 };
+    const bets = [
+      { id: 'b1', battle_id: 'battleX', user_id: 'fan1', side: 'player1', amount: 30, settled: false },
+      { id: 'b2', battle_id: 'battleX', user_id: 'fan2', side: 'player1', amount: 70, settled: false },
+      { id: 'b3', battle_id: 'battleX', user_id: 'fan3', side: 'player2', amount: 100, settled: false }
+    ];
+    const supabase = makeSupabaseMock({ userCredits, bets });
+    // Sobre-escribimos from('battle_bets') para simular la cadena real de
+    // Supabase: select().eq('battle_id',x).eq('settled',false) donde la
+    // ULTIMA llamada de la cadena es awaitable (resuelve {data, error}).
+    const originalFrom = supabase.from.bind(supabase);
+    supabase.from = (table) => {
+      if (table === 'battle_bets') {
+        return {
+          select() { this._eqCount = 0; return this; },
+          eq(col, val) {
+            this._eqCount = (this._eqCount || 0) + 1;
+            if (col === 'battle_id') this._battleId = val;
+            if (this._eqCount >= 2) {
+              return Promise.resolve({
+                data: bets.filter((b) => b.battle_id === this._battleId && !b.settled),
+                error: null
+              });
+            }
+            return this;
+          },
+          update() { return { eq: () => Promise.resolve({ error: null }) }; }
+        };
+      }
+      return originalFrom(table);
+    };
+
+    const handler = makeSettleHandler(supabase);
+    const req = { params: { battleId: 'battleX' }, body: { winningSide: 'player1', artistUserId: 'artist1' } };
+    const res = fakeRes();
+    await handler(req, res);
+    console.log('Caso 4 (liquidar batalla):', res.statusCode, JSON.stringify(res.body));
+    // pozo total = 30+70+100 = 200; winnerPool = 200*0.8 = 160
+    assertEq(res.statusCode, 200, 'Caso4 status');
+    assertEq(userCredits.fan1, 48, 'Caso4 fan1 payout (30/100 del lado ganador * 160)');
+    assertEq(userCredits.fan2, 112, 'Caso4 fan2 payout (70/100 del lado ganador * 160)');
+    assertEq(userCredits.artist1, 20, 'Caso4 artist payout (10% de 200)');
+    assertEq(userCredits.fan3, 0, 'Caso4 fan3 (perdio, no cobra)');
+  }
+
+  console.log(`\n${ok} asserts OK, ${fail} fallos`);
+  if (fail > 0) process.exit(1);
+}
+
+run().catch((e) => { console.error('ERROR:', e); process.exit(1); });

--- a/supabase/migrations/011_battle_bets_multi.sql
+++ b/supabase/migrations/011_battle_bets_multi.sql
@@ -1,0 +1,36 @@
+-- Migration: Apuestas multi-fan por batalla, con reparto 80/10/10
+-- Modelo de negocio (confirmado con el usuario 2026-08-17):
+--   80% del pozo total -> repartido proporcionalmente entre quienes
+--     apostaron por el lado ganador
+--   10% del pozo total -> artista/lado ganador (partner)
+--   10% del pozo total -> plataforma
+-- Tabla nueva, aditiva. No modifica matches/tournaments existentes.
+
+CREATE TABLE IF NOT EXISTS battle_bets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    battle_id UUID NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    side TEXT NOT NULL CHECK (side IN ('player1', 'player2')),
+    amount DECIMAL(20, 4) NOT NULL CHECK (amount > 0),
+    settled BOOLEAN NOT NULL DEFAULT FALSE,
+    payout_credits DECIMAL(20, 4),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    settled_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_battle_bets_battle_id ON battle_bets(battle_id);
+CREATE INDEX IF NOT EXISTS idx_battle_bets_user_id ON battle_bets(user_id);
+CREATE INDEX IF NOT EXISTS idx_battle_bets_battle_settled ON battle_bets(battle_id, settled);
+
+-- Una batalla no debe poder liquidarse dos veces: guardamos el resultado
+-- agregado una sola vez por battle_id.
+CREATE TABLE IF NOT EXISTS battle_settlements (
+    battle_id UUID PRIMARY KEY,
+    winning_side TEXT NOT NULL CHECK (winning_side IN ('player1', 'player2')),
+    total_pool DECIMAL(20, 4) NOT NULL,
+    platform_cut DECIMAL(20, 4) NOT NULL,
+    artist_cut DECIMAL(20, 4) NOT NULL,
+    winner_pool DECIMAL(20, 4) NOT NULL,
+    artist_user_id UUID REFERENCES users(id),
+    settled_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/tests/test_battle_settlement.js
+++ b/tests/test_battle_settlement.js
@@ -1,0 +1,92 @@
+/**
+ * Tests de la logica de liquidacion 80/10/10. Correr con: node tests/test_battle_settlement.js
+ * Sin dependencias de Supabase — prueba solo la funcion pura.
+ */
+const assert = require('assert');
+const { computeSettlement } = require('../backend/battle-settlement');
+
+let passed = 0;
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`OK   - ${name}`);
+    passed++;
+  } catch (e) {
+    console.error(`FAIL - ${name}`);
+    console.error('     ', e.message);
+    process.exitCode = 1;
+  }
+}
+
+// Caso del ejemplo exacto del usuario: A apuesta 50 (player1), B apuesta 50 (player2), gana player2
+check('Ejemplo 1v1 del usuario: 50 vs 50, pozo 100 -> 80/10/10', () => {
+  const bets = [
+    { userId: 'A', side: 'player1', amount: 50 },
+    { userId: 'B', side: 'player2', amount: 50 }
+  ];
+  const r = computeSettlement(bets, 'player2');
+  assert.strictEqual(r.totalPool, 100);
+  assert.strictEqual(r.platformCut, 10);
+  assert.strictEqual(r.artistCut, 10);
+  assert.strictEqual(r.winnerPool, 80);
+  assert.strictEqual(r.payouts.length, 1);
+  assert.strictEqual(r.payouts[0].userId, 'B');
+  assert.strictEqual(r.payouts[0].amount, 80);
+});
+
+// Varios fans por lado, reparto proporcional
+check('Multi-fan: 3 apuestan por el ganador en proporciones distintas', () => {
+  const bets = [
+    { userId: 'winner1', side: 'player1', amount: 30 }, // 30% del lado ganador
+    { userId: 'winner2', side: 'player1', amount: 50 }, // 50%
+    { userId: 'winner3', side: 'player1', amount: 20 }, // 20%
+    { userId: 'loser1', side: 'player2', amount: 40 },
+    { userId: 'loser2', side: 'player2', amount: 60 }
+  ];
+  const r = computeSettlement(bets, 'player1');
+  assert.strictEqual(r.totalPool, 200);
+  assert.strictEqual(r.platformCut, 20);
+  assert.strictEqual(r.artistCut, 20);
+  assert.strictEqual(r.winnerPool, 160);
+  const byUser = Object.fromEntries(r.payouts.map((p) => [p.userId, p.amount]));
+  assert.strictEqual(byUser.winner1, 48);  // 30% de 160
+  assert.strictEqual(byUser.winner2, 80);  // 50% de 160
+  assert.strictEqual(byUser.winner3, 32);  // 20% de 160
+  const sumPayouts = r.payouts.reduce((s, p) => s + p.amount, 0);
+  assert.strictEqual(Math.round(sumPayouts * 10000) / 10000, r.winnerPool);
+});
+
+check('Conciliacion exacta: platformCut + artistCut + sum(payouts) == totalPool', () => {
+  const bets = [
+    { userId: 'u1', side: 'player1', amount: 33.33 },
+    { userId: 'u2', side: 'player1', amount: 17.77 },
+    { userId: 'u3', side: 'player2', amount: 12.5 }
+  ];
+  const r = computeSettlement(bets, 'player1');
+  const sumPayouts = r.payouts.reduce((s, p) => s + p.amount, 0);
+  const reconciled = Math.round((r.platformCut + r.artistCut + sumPayouts) * 10000) / 10000;
+  assert.strictEqual(reconciled, r.totalPool);
+});
+
+check('Nadie aposto por el ganador -> payouts vacio, no se pierde info', () => {
+  const bets = [{ userId: 'u1', side: 'player2', amount: 100 }];
+  const r = computeSettlement(bets, 'player1');
+  assert.strictEqual(r.payouts.length, 0);
+  assert.strictEqual(r.winningSideTotal, 0);
+});
+
+check('Rechaza lado invalido', () => {
+  assert.throws(() => computeSettlement([{ userId: 'u1', side: 'player1', amount: 10 }], 'player3'));
+});
+
+check('Rechaza monto invalido', () => {
+  assert.throws(() =>
+    computeSettlement([{ userId: 'u1', side: 'player1', amount: -5 }], 'player1')
+  );
+});
+
+check('Rechaza array vacio', () => {
+  assert.throws(() => computeSettlement([], 'player1'));
+});
+
+console.log(`\n${passed} tests OK` + (process.exitCode ? ' (con fallas, ver arriba)' : ''));


### PR DESCRIPTION
Nuevo modelo de negocio confirmado con el usuario: fans apuestan por un lado de la batalla (no por su propio resultado como jugador), y al resolverse:
  - 80% del pozo total se reparte PROPORCIONALMENTE entre los fans que apostaron por el lado ganador
  - 10% va al artista/lado ganador (socio)
  - 10% va a la plataforma

Piezas nuevas, aditivas (no tocan el sistema 1v1 de torneos existente):
  - backend/battle-settlement.js: funcion pura computeSettlement(), probada con 7 tests (incluye reconciliacion exacta de centavos)
  - backend/battle-bets-api.js: POST /api/battles/:id/bet (autenticado por Bearer token, nunca confia en userId del body) y POST /api/battles/:id/settle (protegido con requireInternalSecret)
  - supabase/migrations/011_battle_bets_multi.sql: tablas battle_bets y battle_settlements
  - scripts/verify-battle-bets-api.js: 9 asserts contra mocks de Supabase, incluyendo liquidacion con multiples apostadores

Pendiente (no incluido en este cambio): conectar esto al frontend real y decidir como se determina el ganador de una batalla real (streams, votos, etc.) - hoy el endpoint /settle recibe winningSide explicito, no lo calcula solo.