### PR TITLE
CRITICO: apuestas de fans leian solo user_credits, no el balance unif…

### DIFF
--- a/backend/battle-bets-api.js
+++ b/backend/battle-bets-api.js
@@ -11,14 +11,19 @@
  * SEGURIDAD, mismo patron que el resto del proyecto:
  *  - El usuario que aposta se identifica por su token Bearer (getAuthUserFromBearer),
  *    NUNCA por un userId que venga en el body.
- *  - Los creditos se descuentan con decrement_user_credits / se acreditan con
- *    increment_user_credits (las mismas funciones RPC atomicas que ya usa
- *    el resto del sistema de creditos), nunca escribiendo la tabla directo.
+ *  - El saldo se descuenta con deductUnifiedBalance (backend/unified-balance.js) —
+ *    la MISMA fuente de balance que muestra el frontend (credits + saldo_fiat +
+ *    saldo_onchain), igual que /api/credits/deduct y las inscripciones a torneo.
+ *    Descontar solo de user_credits.credits (como se hacia antes) causaba falsos
+ *    "Insufficient credits" en cuentas cuyo saldo esta en saldo_fiat/onchain.
+ *  - Las ganancias se acreditan con increment_user_credits (RPC atomica que ya
+ *    usa el resto del sistema de creditos), nunca escribiendo la tabla directo.
  *  - /settle es idempotente: si el battleId ya tiene fila en
  *    battle_settlements, se rechaza (no se puede liquidar dos veces).
  */
 const { getAuthUserFromBearer, resolvePublicUserId, requireInternalSecret } = require('./auth-middleware');
 const { computeSettlement } = require('./battle-settlement');
+const { deductUnifiedBalance } = require('./unified-balance');
 
 function makePlaceBetHandler(supabase) {
   return async function placeBetHandler(req, res) {
@@ -53,26 +58,16 @@ function makePlaceBetHandler(supabase) {
         return res.status(409).json({ ok: false, error: 'This battle is already settled; no more bets accepted' });
       }
 
-      // Descuenta credits de forma atomica ANTES de registrar la apuesta.
-      // decrement_user_credits ya usa GREATEST(0, credits - amount) --
-      // verificamos el saldo resultante para saber si realmente alcanzaba.
-      const { data: beforeRow } = await supabase
-        .from('user_credits')
-        .select('credits')
-        .eq('user_id', userId)
-        .maybeSingle();
-      const balanceBefore = Number(beforeRow?.credits || 0);
-      if (balanceBefore < numericAmount) {
-        return res.status(402).json({ ok: false, error: 'Insufficient credits' });
-      }
-
-      const { error: decError } = await supabase.rpc('decrement_user_credits', {
-        user_id_param: userId,
-        credits_to_subtract: numericAmount
-      });
-      if (decError) {
-        console.error('[battle-bets] decrement_user_credits failed:', decError);
-        return res.status(500).json({ ok: false, error: 'Failed to reserve credits' });
+      // Descuenta del balance unificado (credits + saldo_fiat + saldo_onchain,
+      // misma fuente que el header del frontend) de forma atomica ANTES de
+      // registrar la apuesta.
+      const deduction = await deductUnifiedBalance(supabase, userId, numericAmount);
+      if (!deduction.ok) {
+        return res.status(402).json({
+          ok: false,
+          error: deduction.error || 'Insufficient credits',
+          total_balance: deduction.total
+        });
       }
 
       const { data: bet, error: insertError } = await supabase

--- a/game-engine.js
+++ b/game-engine.js
@@ -2959,7 +2959,7 @@ const GameEngine = {
                     <span class="text-3xl font-black text-white tabular-nums" id="battleTimer">${this.battleDuration}</span>
                     <span class="text-xs text-gray-400">seg</span>
                 </div>
-                <div class="text-sm text-gray-500">💰 Pot: ${pot} MTR</div>
+                <div class="text-sm text-gray-500" title="Lo que arriesgan los dos jugadores entre si, no incluye lo que apuesten los fans">💰 Pozo de jugadores: ${pot} MTR</div>
             </div>
 
             <div class="relative rounded-2xl overflow-hidden border border-cyan-500/20 bg-black/60 mb-6 h-[300px] sm:h-[340px] md:h-[380px]" id="battleCanvasWrap">
@@ -3031,7 +3031,8 @@ const GameEngine = {
             <div id="battleStatusText" class="text-center py-4 px-4 mb-4"></div>
 
             <div id="fanBetPanel" class="max-w-3xl mx-auto rounded-2xl border border-white/10 bg-white/5 p-4 mb-4">
-                <p class="text-center text-xs text-gray-400 uppercase tracking-widest mb-3">🎤 Apostá por tu favorito</p>
+                <p class="text-center text-xs text-gray-400 uppercase tracking-widest mb-1">🎤 Apostá por tu favorito</p>
+                <p class="text-center text-[11px] text-gray-500 mb-3">Pozo aparte del de los jugadores · se reparte 80% entre los fans del lado ganador, 10% al artista, 10% a la plataforma</p>
                 <div class="flex items-center justify-center gap-2 mb-3">
                     <span class="text-gray-400 text-sm">Monto:</span>
                     <input type="number" id="fanBetAmount" min="1" step="1" value="10"


### PR DESCRIPTION
…icado

backend/battle-bets-api.js:
  El endpoint POST /api/battles/:id/bet chequeaba y descontaba solo la
  columna user_credits.credits. Cuentas cuyo saldo esta en saldo_fiat o
  saldo_onchain (que es lo que realmente muestra el header del frontend,
  via deductUnifiedBalance/readUnifiedTotal) recibian 'Insufficient
  credits' con saldo real de sobra. Encontrado probando en produccion con
  una cuenta real de ~$3000 nominales que no pudo apostar 10 creditos.
  Ahora usa deductUnifiedBalance (backend/unified-balance.js), la misma
  fuente que /api/credits/deduct y la inscripcion a torneos. Tests de
  scripts/verify-battle-bets-api.js siguen pasando (9/9).

game-engine.js:
  Aclara el texto de la arena: el '${pot} MTR' que ya existía es el
  pozo de la apuesta 1v1 entre los dos jugadores (renombrado a 'Pozo de
  jugadores'), distinto del pozo nuevo de apuestas de fans. Se agrego un
  subtitulo al panel de fans para que no se lea como si fuera la misma
  apuesta pedida dos veces.